### PR TITLE
fix: agent-events stream blockers (tts/stt/streaming/db baseline)

### DIFF
--- a/apps/cli/src/hooks/useMutation.ts
+++ b/apps/cli/src/hooks/useMutation.ts
@@ -13,15 +13,16 @@ export interface UseMutationResult<T, E, V> {
   reset: () => void;
 }
 
-export interface UseMutationOptions<T> {
+export interface UseMutationOptions<T, E = Error> {
   onSuccess?: (data: T) => void;
+  onError?: (err: E) => void;
 }
 
 export function useMutation<T, E = Error, V = void>(
   mutationFn: (variables: V) => ResultAsync<T, E>,
-  options?: UseMutationOptions<T>,
+  options?: UseMutationOptions<T, E>,
 ): UseMutationResult<T, E, V> {
-  const { onSuccess } = options ?? {};
+  const { onSuccess, onError } = options ?? {};
   const [data, setData] = useState<T | undefined>(undefined);
   const [error, setError] = useState<E | null>(null);
   const [isPending, setIsPending] = useState(false);
@@ -40,6 +41,7 @@ export function useMutation<T, E = Error, V = void>(
         .orTee((err) => {
           setError(err);
           setData(undefined);
+          onError?.(err);
         })
         .match(
           () => setIsPending(false),
@@ -47,7 +49,7 @@ export function useMutation<T, E = Error, V = void>(
         );
       return ok(undefined);
     },
-    [mutationFn, onSuccess],
+    [mutationFn, onSuccess, onError],
   );
 
   const mutateAsync = useCallback(
@@ -64,11 +66,12 @@ export function useMutation<T, E = Error, V = void>(
         .orTee((err) => {
           setError(err);
           setData(undefined);
+          onError?.(err);
         })
         .andTee(() => setIsPending(false))
         .orTee(() => setIsPending(false));
     },
-    [mutationFn, onSuccess],
+    [mutationFn, onSuccess, onError],
   );
 
   const reset = useCallback(() => {

--- a/apps/cli/src/screens/chat/events.test.ts
+++ b/apps/cli/src/screens/chat/events.test.ts
@@ -62,6 +62,42 @@ describe("chat events", () => {
     expect(deriveStreamingResponse(events)).toBe("");
   });
 
+  test("isReplace streaming event resets accumulated content", () => {
+    const events: ChatEvent[] = [
+      createChatEvent({
+        ...base,
+        type: "message.assistant.streaming",
+        messageId: "msg_1",
+        delta: "partial reply",
+        isComplete: false,
+      }),
+      createChatEvent({
+        ...base,
+        type: "message.assistant.streaming",
+        messageId: "msg_1",
+        delta: "totally different start",
+        isComplete: false,
+        isReplace: true,
+      }),
+    ];
+
+    expect(deriveStreamingResponse(events)).toBe("totally different start");
+
+    events.push(
+      createChatEvent({
+        ...base,
+        type: "message.assistant.streaming",
+        messageId: "msg_1",
+        delta: " continued",
+        isComplete: false,
+      }),
+    );
+
+    expect(deriveStreamingResponse(events)).toBe(
+      "totally different start continued",
+    );
+  });
+
   test("derives active tool from unmatched call/result events", () => {
     const first = "tool_1";
     const second = "tool_2";

--- a/apps/cli/src/screens/chat/events.ts
+++ b/apps/cli/src/screens/chat/events.ts
@@ -33,6 +33,9 @@ export interface AssistantStreamingMessageEvent extends BaseChatEvent {
   messageId: string;
   delta: string;
   isComplete: boolean;
+  /** When true, `delta` replaces the accumulated text instead of being appended.
+   *  Used when the provider replays content from the start mid-stream. */
+  isReplace?: boolean;
 }
 
 export interface AssistantMessageEvent extends BaseChatEvent {
@@ -68,7 +71,7 @@ export interface TtsStartEvent extends BaseChatEvent {
 
 export interface TtsEndEvent extends BaseChatEvent {
   type: "tts.end";
-  status: "success" | "error";
+  status: "success" | "error" | "cancelled";
   elapsedMs: number;
   error?: string;
 }
@@ -172,7 +175,8 @@ export function deriveMessages(events: readonly ChatEvent[]): ChatMessage[] {
     } else if (event.type === "message.assistant.streaming") {
       if (!finalizedMessageIds.has(event.messageId)) {
         const current = streamingByMessageId.get(event.messageId) ?? "";
-        streamingByMessageId.set(event.messageId, current + event.delta);
+        const next = event.isReplace ? event.delta : current + event.delta;
+        streamingByMessageId.set(event.messageId, next);
       }
     } else if (event.type === "message.assistant") {
       finalizedMessageIds.add(event.messageId);
@@ -196,7 +200,8 @@ export function deriveStreamingResponse(events: readonly ChatEvent[]): string {
       latestMessageId = event.messageId;
       if (!finalizedMessageIds.has(event.messageId)) {
         const current = streamingByMessageId.get(event.messageId) ?? "";
-        streamingByMessageId.set(event.messageId, current + event.delta);
+        const next = event.isReplace ? event.delta : current + event.delta;
+        streamingByMessageId.set(event.messageId, next);
       }
     } else if (event.type === "message.assistant") {
       finalizedMessageIds.add(event.messageId);

--- a/apps/cli/src/screens/chat/store.tsx
+++ b/apps/cli/src/screens/chat/store.tsx
@@ -62,7 +62,8 @@ function useChatStoreLogic(initialState?: ChatStoreInitialState) {
   const runStartedAtRef = useRef(0);
   const lastStreamingTextRef = useRef("");
   const firstTokenAtRef = useRef<number | null>(null);
-  const ttsStartedAtRef = useRef(0);
+  const ttsStartedAtRef = useRef<number | null>(null);
+  const ttsModeRef = useRef<"direct" | "narration" | null>(null);
   const sttRunIdRef = useRef<string | null>(null);
   const sttStartedAtRef = useRef(0);
   const activeToolIdsRef = useRef(
@@ -167,11 +168,11 @@ function useChatStoreLogic(initialState?: ChatStoreInitialState) {
       mcpConfigPath,
       messages: priorMessages,
       onUpdate: (text) => {
-        if (!firstTokenAtRef.current) firstTokenAtRef.current = Date.now();
+        if (firstTokenAtRef.current === null)
+          firstTokenAtRef.current = Date.now();
         const previous = lastStreamingTextRef.current;
-        const delta = text.startsWith(previous)
-          ? text.slice(previous.length)
-          : text;
+        const isReplace = !text.startsWith(previous);
+        const delta = isReplace ? text : text.slice(previous.length);
         lastStreamingTextRef.current = text;
         if (!delta) return;
         emit({
@@ -181,6 +182,7 @@ function useChatStoreLogic(initialState?: ChatStoreInitialState) {
           messageId: assistantMessageId,
           delta,
           isComplete: false,
+          ...(isReplace && { isReplace: true }),
         });
       },
       abortController: chatAbortRef.current,
@@ -222,7 +224,24 @@ function useChatStoreLogic(initialState?: ChatStoreInitialState) {
       .andThen((text) => {
         if (!text) return okAsync(null);
         const modelForNarration = narrationModel || model;
+        const beginTtsPhase = (mode: "direct" | "narration") => {
+          ttsStartedAtRef.current = Date.now();
+          ttsModeRef.current = mode;
+        };
+        const endTtsPhase = (status: "success") => {
+          const startedAt = ttsStartedAtRef.current ?? Date.now();
+          ttsStartedAtRef.current = null;
+          ttsModeRef.current = null;
+          emit({
+            type: "tts.end",
+            runId,
+            conversationId: conversationIdRef.current,
+            status,
+            elapsedMs: Date.now() - startedAt,
+          });
+        };
         if (useNarrationForTTS && modelForNarration) {
+          beginTtsPhase("narration");
           emit({
             type: "tts.start",
             runId,
@@ -239,7 +258,8 @@ function useChatStoreLogic(initialState?: ChatStoreInitialState) {
           })
             .map((narration) => narration.trim() || text)
             .andThen((toSpeak) => {
-              ttsStartedAtRef.current = Date.now();
+              endTtsPhase("success");
+              beginTtsPhase("direct");
               emit({
                 type: "tts.start",
                 runId,
@@ -249,18 +269,12 @@ function useChatStoreLogic(initialState?: ChatStoreInitialState) {
                 contentLength: toSpeak.length,
               });
               return speak(toSpeak, { voice }).map(() => {
-                emit({
-                  type: "tts.end",
-                  runId,
-                  conversationId: conversationIdRef.current,
-                  status: "success",
-                  elapsedMs: Date.now() - ttsStartedAtRef.current,
-                });
+                endTtsPhase("success");
                 return text;
               });
             });
         }
-        ttsStartedAtRef.current = Date.now();
+        beginTtsPhase("direct");
         emit({
           type: "tts.start",
           runId,
@@ -270,13 +284,7 @@ function useChatStoreLogic(initialState?: ChatStoreInitialState) {
           contentLength: text.length,
         });
         return speak(text, { voice }).map(() => {
-          emit({
-            type: "tts.end",
-            runId,
-            conversationId: conversationIdRef.current,
-            status: "success",
-            elapsedMs: Date.now() - ttsStartedAtRef.current,
-          });
+          endTtsPhase("success");
           return text;
         });
       })
@@ -290,7 +298,7 @@ function useChatStoreLogic(initialState?: ChatStoreInitialState) {
             messageId: assistantMessageId,
             content: res,
             finishReason: "stop",
-            ...(firstTokenAtRef.current && {
+            ...(firstTokenAtRef.current !== null && {
               ttftMs: firstTokenAtRef.current - runStartedAtRef.current,
             }),
             ttltMs,
@@ -328,6 +336,18 @@ function useChatStoreLogic(initialState?: ChatStoreInitialState) {
       .mapErr((err) => {
         const elapsedMs = Date.now() - runStartedAtRef.current;
         const status = err.name === "AbortError" ? "cancelled" : "error";
+        if (ttsStartedAtRef.current !== null) {
+          emit({
+            type: "tts.end",
+            runId,
+            conversationId: conversationIdRef.current,
+            status,
+            elapsedMs: Date.now() - ttsStartedAtRef.current,
+            error: err.message,
+          });
+          ttsStartedAtRef.current = null;
+          ttsModeRef.current = null;
+        }
         emit({
           type: "system",
           runId,
@@ -382,8 +402,23 @@ function useChatStoreLogic(initialState?: ChatStoreInitialState) {
             elapsedMs,
           });
         }
+        sttRunIdRef.current = null;
         if (transcript)
           setValue((p) => (p ? `${p} ${transcript}` : transcript));
+      },
+      onError: (err) => {
+        const runId = sttRunIdRef.current;
+        if (!runId) return;
+        const status = err.name === "AbortError" ? "cancelled" : "error";
+        emit({
+          type: "stt.end",
+          runId,
+          conversationId: conversationIdRef.current,
+          status,
+          elapsedMs: Date.now() - sttStartedAtRef.current,
+          error: err.message,
+        });
+        sttRunIdRef.current = null;
       },
     },
   );

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -26,10 +26,29 @@ import * as schema from "./schema.js";
 
 const packageDir = path.dirname(path.dirname(fileURLToPath(import.meta.url)));
 const migrationsFolder = path.join(packageDir, "drizzle");
+const initialMigrationTag = "0000_known_whizzer";
 const initialMigrationFile = path.join(
   migrationsFolder,
-  "0000_known_whizzer.sql",
+  `${initialMigrationTag}.sql`,
 );
+const journalFile = path.join(migrationsFolder, "meta", "_journal.json");
+
+interface DrizzleJournalEntry {
+  idx: number;
+  tag: string;
+  when: number;
+}
+
+function readJournalWhen(tag: string): number {
+  try {
+    const journal = JSON.parse(readFileSync(journalFile, "utf8")) as {
+      entries: DrizzleJournalEntry[];
+    };
+    return journal.entries.find((e) => e.tag === tag)?.when ?? 0;
+  } catch {
+    return 0;
+  }
+}
 
 const PRAGMA_SQL = `
   PRAGMA journal_mode = WAL;
@@ -132,6 +151,11 @@ function baselineLegacyDrizzleMigration(sqlite: Database): void {
   ensureLegacyBaselineSchema(sqlite);
   const migrationSql = readFileSync(initialMigrationFile, "utf8");
   const hash = createHash("sha256").update(migrationSql).digest("hex");
+  // `created_at` must match the migration's journal `when` so drizzle's
+  // `entry.when > lastCreatedAt` comparison applies future migrations.
+  // Using `Date.now()` here would silently skip any migration whose
+  // generation timestamp is older than the baseline-insertion clock.
+  const createdAt = readJournalWhen(initialMigrationTag);
   sqlite.exec(`
     CREATE TABLE IF NOT EXISTS "__drizzle_migrations" (
       id SERIAL PRIMARY KEY,
@@ -143,7 +167,7 @@ function baselineLegacyDrizzleMigration(sqlite: Database): void {
     .prepare(
       'INSERT INTO "__drizzle_migrations" ("hash", "created_at") VALUES (?, ?)',
     )
-    .run(hash, Date.now());
+    .run(hash, createdAt);
 }
 
 export interface YapprDb {


### PR DESCRIPTION
## Summary

Patches the four blockers flagged in the review of #4.

- **chat/store.tsx** — TTS narration phase now closes its own `tts.end` before the direct phase begins; `.mapErr` closes any open TTS phase with status `cancelled`/`error`.
- **chat/store.tsx** — STT mutation gains `onError`, emitting `stt.end` with `cancelled` (AbortError) or `error`. `useMutation` grows an `onError` option to support this.
- **chat/events.ts + store.tsx** — Streaming events get an optional `isReplace` flag. When the provider replays text from the start mid-stream (`text` doesn't start with the accumulated previous), the emitter sets `isReplace: true` and derivers replace instead of appending, eliminating UI duplication.
- **db/client.ts** — Legacy-baseline insert into `__drizzle_migrations` now uses the migration's own `_journal.json` `when` instead of `Date.now()`, so future migrations aren't silently skipped on databases that took the legacy path.

Side cleanup: `tts.end` status union picks up `cancelled`; `firstTokenAtRef` truthy check tightened to explicit null compare.

## Test plan
- [x] `bun run check` (format + lint + typecheck + 38 tests pass)
- [x] New events test covers `isReplace` replace-then-append behavior
- [ ] Manual: run a chat with narration TTS, abort mid-narration — `tts.end` should land in the event stream
- [ ] Manual: start STT, abort recording — `stt.end` with `status: "cancelled"` should land
- [ ] Manual: open a legacy DB (pre-drizzle) and run; verify `__drizzle_migrations.created_at` matches journal `when`