### PR TITLE
feat(sdk/mcp): per-server timeoutMs + lifecycle events

### DIFF
--- a/apps/desktop/README.md
+++ b/apps/desktop/README.md
@@ -19,6 +19,23 @@ bun run dev       # Electrobun loading bundled assets (no HMR)
 bun run start     # build once then run Electrobun against bundled assets
 ```
 
+### Ollama CORS
+
+Ollama (since 0.1.24) only accepts cross-origin requests from origins
+on its allow-list. The packaged build loads from `views://mainview`,
+which is not on the default list, so `bun run start` will see
+`403 Access-Control-Allow-Origin` on every Ollama call. Fix by
+exporting one of these before `ollama serve`:
+
+```bash
+export OLLAMA_ORIGINS='views://*'    # narrowest — only Electrobun renderers
+# or
+export OLLAMA_ORIGINS='*'            # any origin — convenient for local dev
+```
+
+`bun run dev:hmr` is unaffected because Vite proxies `/ollama` →
+`127.0.0.1:11434` (see `vite.config.ts` and `lib/ollama.ts`).
+
 ## How it fits together
 
 - **`src/bun/`** — Electrobun main process. Owns the `~/.yappr/yappr.db` SQLite handle (shared with the CLI) and registers the typed `@yappr/db/rpc` request handlers.

--- a/apps/desktop/electrobun.config.ts
+++ b/apps/desktop/electrobun.config.ts
@@ -10,6 +10,10 @@ export default {
     copy: {
       "dist/index.html": "views/mainview/index.html",
       "dist/assets": "views/mainview/assets",
+      // Drizzle migrations (SQL + journal). Required at runtime by
+      // @yappr/db's createDb -> migrate() and the legacy-baseline
+      // path that reads 0000_known_whizzer.sql for its hash.
+      "../../packages/db/drizzle": "drizzle",
     },
     watchIgnore: ["dist/**"],
     // Pin renderer per platform. Keep `bundleCEF: false` everywhere so we ship

--- a/packages/sdk/src/mcp.test.ts
+++ b/packages/sdk/src/mcp.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, test } from "bun:test";
+
+import { McpConfigSchema, McpServerConfigSchema } from "./schemas.js";
+
+describe("McpServerConfigSchema", () => {
+  test("accepts a stdio server with optional timeoutMs", () => {
+    const parsed = McpServerConfigSchema.parse({
+      command: "npx",
+      args: ["-y", "@modelcontextprotocol/server-filesystem", "/tmp"],
+      timeoutMs: 5000,
+    });
+    expect(parsed.timeoutMs).toBe(5000);
+  });
+
+  test("allows config without timeoutMs", () => {
+    const parsed = McpServerConfigSchema.parse({
+      url: "http://localhost:9000",
+    });
+    expect(parsed.timeoutMs).toBeUndefined();
+  });
+
+  test("rejects non-positive timeoutMs", () => {
+    expect(() =>
+      McpServerConfigSchema.parse({ command: "x", timeoutMs: 0 }),
+    ).toThrow();
+    expect(() =>
+      McpServerConfigSchema.parse({ command: "x", timeoutMs: -1 }),
+    ).toThrow();
+  });
+
+  test("rejects non-integer timeoutMs", () => {
+    expect(() =>
+      McpServerConfigSchema.parse({ command: "x", timeoutMs: 1.5 }),
+    ).toThrow();
+  });
+});
+
+describe("McpConfigSchema", () => {
+  test("parses a multi-server config", () => {
+    const parsed = McpConfigSchema.parse({
+      mcpServers: {
+        fs: { command: "npx", args: ["-y", "fs-server"] },
+        gh: { url: "https://gh.example", timeoutMs: 10_000 },
+      },
+    });
+    expect(Object.keys(parsed.mcpServers)).toEqual(["fs", "gh"]);
+    expect(parsed.mcpServers.gh?.timeoutMs).toBe(10_000);
+  });
+
+  test("rejects missing mcpServers", () => {
+    expect(() => McpConfigSchema.parse({})).toThrow();
+  });
+});

--- a/packages/sdk/src/mcp.ts
+++ b/packages/sdk/src/mcp.ts
@@ -11,40 +11,102 @@ import type {
 } from "@modelcontextprotocol/sdk/types.js";
 import { toolDefinition, type SchemaInput, type Tool } from "@tanstack/ai";
 import { toError } from "@yappr/lib/result";
-import { errAsync, ResultAsync } from "neverthrow";
+import { errAsync, okAsync, ResultAsync } from "neverthrow";
 import type { Tool as OllamaTool } from "ollama";
 
 import { resolveMcpConfigPath } from "./paths.js";
-import type {
-  McpConfig,
-  McpServerConfig,
-  ServerStatus,
-  TransportKind,
-} from "./types.js";
+import { McpConfigSchema } from "./schemas.js";
+import type { McpServerConfig, ServerStatus, TransportKind } from "./types.js";
+
+export type McpLifecycleEvent =
+  | { type: "server.connecting"; serverId: string; transport?: TransportKind }
+  | {
+      type: "server.connected";
+      serverId: string;
+      transport: TransportKind;
+      toolCount: number;
+      elapsedMs: number;
+    }
+  | {
+      type: "server.error";
+      serverId: string;
+      phase: "connect" | "list-tools" | "call-tool";
+      error: string;
+      toolName?: string;
+    }
+  | { type: "server.disconnected"; serverId: string }
+  | {
+      type: "tool.call.timeout";
+      serverId: string;
+      toolName: string;
+      timeoutMs: number;
+    };
+
+export interface McpManagerOptions {
+  /** Default timeout (ms) for tool calls when a server config doesn't specify one. */
+  defaultTimeoutMs?: number;
+  /** Fire-and-forget lifecycle callback. Synchronous; do not throw. */
+  onEvent?: (event: McpLifecycleEvent) => void;
+}
+
+const DEFAULT_TOOL_CALL_TIMEOUT_MS = 30_000;
 
 export class McpManager {
   private clients: Map<string, Client> = new Map();
   private tools: Map<string, { server: string; tool: McpTool }> = new Map();
+  private serverTimeouts: Map<string, number> = new Map();
+  private readonly defaultTimeoutMs: number;
+  private readonly onEvent: (event: McpLifecycleEvent) => void;
+
+  constructor(options: McpManagerOptions = {}) {
+    this.defaultTimeoutMs =
+      options.defaultTimeoutMs ?? DEFAULT_TOOL_CALL_TIMEOUT_MS;
+    this.onEvent = options.onEvent ?? (() => {});
+  }
+
+  private emit(event: McpLifecycleEvent): void {
+    try {
+      this.onEvent(event);
+    } catch (err) {
+      console.warn("[yappr] mcp onEvent threw:", err);
+    }
+  }
+
+  private resolveTimeoutMs(serverId: string): number {
+    return this.serverTimeouts.get(serverId) ?? this.defaultTimeoutMs;
+  }
 
   loadConfigAndGetStatuses(
     configPath: string = resolveMcpConfigPath(),
   ): ResultAsync<ServerStatus[], Error> {
     return ResultAsync.fromPromise(
-      (async (): Promise<ServerStatus[]> => {
+      (async () => {
         const file = Bun.file(configPath);
-        if (!(await file.exists())) return [];
-
-        const content = await file.text();
-        const config = JSON.parse(content) as McpConfig;
-        const results: ServerStatus[] = [];
-        for (const [id, serverConfig] of Object.entries(config.mcpServers)) {
-          const status = await this.connectToServer(id, serverConfig);
-          results.push(status);
-        }
-        return results;
+        return (await file.exists()) ? await file.text() : null;
       })(),
       toError,
-    );
+    ).andThen((content) => {
+      if (content === null) return okAsync([] as ServerStatus[]);
+      const parsed = McpConfigSchema.safeParse(JSON.parse(content));
+      if (!parsed.success) {
+        return errAsync(
+          new Error(`Invalid MCP config: ${parsed.error.message}`),
+        );
+      }
+      return ResultAsync.fromSafePromise(
+        this.connectAll(parsed.data.mcpServers),
+      );
+    });
+  }
+
+  private async connectAll(
+    servers: Record<string, McpServerConfig>,
+  ): Promise<ServerStatus[]> {
+    const results: ServerStatus[] = [];
+    for (const [id, serverConfig] of Object.entries(servers)) {
+      results.push(await this.connectToServer(id, serverConfig));
+    }
+    return results;
   }
 
   /** True when Streamable HTTP failed with 4xx — retry with SSE. */
@@ -60,11 +122,20 @@ export class McpManager {
     id: string,
     config: McpServerConfig,
   ): Promise<ServerStatus> {
+    if (config.timeoutMs !== undefined) {
+      this.serverTimeouts.set(id, config.timeoutMs);
+    }
     try {
       if (config.command) {
+        this.emit({
+          type: "server.connecting",
+          serverId: id,
+          transport: "stdio",
+        });
         return await this.connectWithStdio(id, config);
       }
       if (config.url) {
+        this.emit({ type: "server.connecting", serverId: id });
         return await this.connectWithUrl(id, config.url);
       }
       return {
@@ -84,6 +155,12 @@ export class McpManager {
       } else if (msg.includes("Non-200")) {
         msg = "Auth/Connection Err";
       }
+      this.emit({
+        type: "server.error",
+        serverId: id,
+        phase: "connect",
+        error: msg,
+      });
       return { id, status: "[FAIL] Failed", tools: 0, message: msg };
     }
   }
@@ -148,13 +225,32 @@ export class McpManager {
     client: Client,
     transport: TransportKind,
   ): Promise<ServerStatus> {
-    const result = await client.listTools();
+    const startedAt = Date.now();
+    let result;
+    try {
+      result = await client.listTools();
+    } catch (err) {
+      this.emit({
+        type: "server.error",
+        serverId: id,
+        phase: "list-tools",
+        error: err instanceof Error ? err.message : String(err),
+      });
+      throw err;
+    }
     const toolCount = result.tools?.length ?? 0;
     if (result.tools) {
       for (const tool of result.tools) {
         this.tools.set(tool.name, { server: id, tool });
       }
     }
+    this.emit({
+      type: "server.connected",
+      serverId: id,
+      transport,
+      toolCount,
+      elapsedMs: Date.now() - startedAt,
+    });
     return {
       id,
       status: "[OK] Connected",
@@ -213,20 +309,62 @@ export class McpManager {
       );
     }
 
+    const timeoutMs = this.resolveTimeoutMs(server);
+    const ac = new AbortController();
+    const timer = setTimeout(() => {
+      ac.abort(
+        new Error(
+          `MCP tool '${name}' on server '${server}' timed out after ${timeoutMs}ms`,
+        ),
+      );
+    }, timeoutMs);
+
     console.log(`Calling MCP tool '${name}' on server '${server}'...`);
     return ResultAsync.fromPromise(
-      client.callTool({ name, arguments: args }) as Promise<CallToolResult>,
+      client.callTool({ name, arguments: args }, undefined, {
+        signal: ac.signal,
+        timeout: timeoutMs,
+      }) as Promise<CallToolResult>,
       toError,
-    );
+    )
+      .mapErr((err) =>
+        ac.signal.aborted && ac.signal.reason instanceof Error
+          ? ac.signal.reason
+          : err,
+      )
+      .orTee((err) => {
+        if (ac.signal.aborted) {
+          this.emit({
+            type: "tool.call.timeout",
+            serverId: server,
+            toolName: name,
+            timeoutMs,
+          });
+        } else {
+          this.emit({
+            type: "server.error",
+            serverId: server,
+            phase: "call-tool",
+            error: err.message,
+            toolName: name,
+          });
+        }
+      })
+      .andTee(() => clearTimeout(timer))
+      .orTee(() => clearTimeout(timer));
   }
 
   async close(): Promise<void> {
-    for (const client of this.clients.values()) {
+    for (const [id, client] of this.clients.entries()) {
       try {
         await client.close();
       } catch {
         /* ignore */
       }
+      this.emit({ type: "server.disconnected", serverId: id });
     }
+    this.clients.clear();
+    this.tools.clear();
+    this.serverTimeouts.clear();
   }
 }

--- a/packages/sdk/src/schemas.ts
+++ b/packages/sdk/src/schemas.ts
@@ -27,3 +27,19 @@ export const TranscribeResponseSchema = z.object({
   text: z.string(),
 });
 export type TranscribeResponse = z.infer<typeof TranscribeResponseSchema>;
+
+export const McpServerConfigSchema = z.object({
+  command: z.string().optional(),
+  args: z.array(z.string()).optional(),
+  env: z.record(z.string(), z.string()).optional(),
+  url: z.string().optional(),
+  name: z.string().optional(),
+  /** Per-server tool-call timeout in ms. Falls back to manager default. */
+  timeoutMs: z.number().int().positive().optional(),
+});
+export type McpServerConfig = z.infer<typeof McpServerConfigSchema>;
+
+export const McpConfigSchema = z.object({
+  mcpServers: z.record(z.string(), McpServerConfigSchema),
+});
+export type McpConfig = z.infer<typeof McpConfigSchema>;

--- a/packages/sdk/src/types.ts
+++ b/packages/sdk/src/types.ts
@@ -9,17 +9,7 @@ export interface RecordOptions {
 
 export type { TTSOptions } from "./tts.js";
 
-export interface McpServerConfig {
-  command?: string;
-  args?: string[];
-  env?: Record<string, string>;
-  url?: string;
-  name?: string;
-}
-
-export interface McpConfig {
-  mcpServers: Record<string, McpServerConfig>;
-}
+export type { McpConfig, McpServerConfig } from "./schemas.js";
 
 export type TransportKind = "stdio" | "streamable-http" | "sse";
 


### PR DESCRIPTION
## Summary

A hanging MCP tool call would freeze the whole chat run because `McpManager.callTool` awaited the SDK call with no upper bound. This PR adds a default 30s tool-call timeout (overridable per-server) and a lifecycle-event callback for observability.

## Changes

- **Schema-first.** `McpServerConfigSchema` / `McpConfigSchema` move into `packages/sdk/src/schemas.ts` with optional positive-integer `timeoutMs`. `types.ts` re-exports the inferred types so consumers keep the same import path. Per CLAUDE.md zod-first guidance.
- **`loadConfigAndGetStatuses`** now parses the config file through `safeParse`. Invalid configs surface as `Result<…, Error>` failures instead of being silently treated as valid.
- **`callTool` timeout.** Wraps the SDK call in an `AbortController` armed with `setTimeout(timeoutMs)`. On abort the original error is replaced with the timeout reason; the timer is cleaned up via `andTee` / `orTee` so success and failure paths both clear it.
- **`McpManagerOptions`.** New optional constructor argument with `defaultTimeoutMs` (30s default) and a synchronous `onEvent` callback. `new McpManager()` keeps working unchanged.
- **`McpLifecycleEvent`.** Union covers `server.connecting` / `server.connected` / `server.error` (phase: connect | list-tools | call-tool) / `server.disconnected` / `tool.call.timeout`.
- **`close()`.** Emits `server.disconnected` per client and clears manager state so a reused manager doesn't leak old tool registrations.

## Test plan
- [x] `bun run check` (format + lint + typecheck + 44 tests pass)
- [x] New schema tests cover valid/invalid `timeoutMs`
- [ ] Manual: configure an MCP server with `timeoutMs: 100`, point at a tool that sleeps 1s, confirm chat run returns within ~100ms with timeout error
- [ ] Manual: misconfigure mcp.json (e.g. wrong type on `args`) and verify `loadConfigAndGetStatuses` returns an Err with the zod message instead of crashing