### PR TITLE
feat(desktop): input-device picker + voice-store on createContainer

### DIFF
--- a/apps/desktop/electrobun.config.ts
+++ b/apps/desktop/electrobun.config.ts
@@ -10,6 +10,10 @@ export default {
     copy: {
       "dist/index.html": "views/mainview/index.html",
       "dist/assets": "views/mainview/assets",
+      // Drizzle migrations (SQL + journal). Required at runtime by
+      // @yappr/db's createDb -> migrate() and the legacy-baseline
+      // path that reads 0000_known_whizzer.sql for its hash.
+      "../../packages/db/drizzle": "drizzle",
     },
     watchIgnore: ["dist/**"],
     // Pin renderer per platform. Keep `bundleCEF: false` everywhere so we ship

--- a/apps/desktop/electrobun.config.ts
+++ b/apps/desktop/electrobun.config.ts
@@ -3,7 +3,7 @@ import type { ElectrobunConfig } from "electrobun";
 export default {
   app: {
     name: "Yappr",
-    identifier: "money.printr.yappr.desktop",
+    identifier: "alanrsoares.me.yappr.desktop",
     version: "0.0.1",
   },
   build: {

--- a/apps/desktop/package.json
+++ b/apps/desktop/package.json
@@ -28,6 +28,7 @@
     "@tanstack/react-query": "^5.100.10",
     "@tanstack/react-router": "^1.169.2",
     "@yappr/db": "workspace:*",
+    "@yappr/lib": "workspace:*",
     "@yappr/sdk": "workspace:*",
     "ai": "^6.0.177",
     "class-variance-authority": "^0.7.1",

--- a/apps/desktop/src/mainview/lib/audio-devices.ts
+++ b/apps/desktop/src/mainview/lib/audio-devices.ts
@@ -1,0 +1,92 @@
+import { useCallback, useEffect, useMemo } from "react";
+
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+
+export interface InputDevice {
+  deviceId: string;
+  label: string;
+}
+
+export interface UseInputDevicesResult {
+  devices: InputDevice[];
+  /** True once `getUserMedia` has been accepted at least once — labels are
+   *  blank until permission is granted, so the UI uses this to gate the
+   *  picker behind a "Grant mic access" button. */
+  permissionGranted: boolean;
+  /** Re-query `enumerateDevices` (invalidates the TanStack Query cache). */
+  refresh: () => Promise<void>;
+  /** Prompt the user for mic access, then refresh. Returns true on success. */
+  requestPermission: () => Promise<boolean>;
+}
+
+const QUERY_KEY = ["audio-devices"] as const;
+
+async function fetchDevices(): Promise<MediaDeviceInfo[]> {
+  if (!navigator.mediaDevices?.enumerateDevices) return [];
+  return navigator.mediaDevices.enumerateDevices();
+}
+
+export function useInputDevices(): UseInputDevicesResult {
+  const queryClient = useQueryClient();
+  const { data } = useQuery({
+    queryKey: QUERY_KEY,
+    queryFn: fetchDevices,
+    staleTime: 30_000,
+  });
+
+  // The `devicechange` event fires when devices are added/removed; treat it
+  // as a cache invalidation signal so the next render re-enumerates.
+  useEffect(() => {
+    if (!navigator.mediaDevices?.addEventListener) return;
+    const onChange = () =>
+      queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+    navigator.mediaDevices.addEventListener("devicechange", onChange);
+    return () =>
+      navigator.mediaDevices.removeEventListener("devicechange", onChange);
+  }, [queryClient]);
+
+  const permission = useMutation({
+    mutationFn: async (): Promise<boolean> => {
+      try {
+        const stream = await navigator.mediaDevices.getUserMedia({
+          audio: true,
+        });
+        for (const track of stream.getTracks()) track.stop();
+        return true;
+      } catch {
+        return false;
+      }
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: QUERY_KEY }),
+  });
+
+  const devices = useMemo<InputDevice[]>(
+    () =>
+      (data ?? [])
+        .filter((d) => d.kind === "audioinput")
+        .map((d, i) => ({
+          deviceId: d.deviceId,
+          label: d.label || `Microphone ${i + 1}`,
+        })),
+    [data],
+  );
+
+  // Browsers withhold device labels until the user has granted mic permission
+  // at least once for the origin. A non-empty label is the only reliable
+  // cross-engine signal that permission has been granted.
+  const permissionGranted = useMemo(
+    () => (data ?? []).some((d) => d.kind === "audioinput" && d.label !== ""),
+    [data],
+  );
+
+  const refresh = useCallback(async () => {
+    await queryClient.invalidateQueries({ queryKey: QUERY_KEY });
+  }, [queryClient]);
+
+  const requestPermission = useCallback(
+    () => permission.mutateAsync(),
+    [permission],
+  );
+
+  return { devices, permissionGranted, refresh, requestPermission };
+}

--- a/apps/desktop/src/mainview/lib/voice-store.tsx
+++ b/apps/desktop/src/mainview/lib/voice-store.tsx
@@ -29,10 +29,6 @@ type VoiceStoreValue = {
   setVoice: (v: VoiceId) => void;
   speed: number;
   setSpeed: (v: number) => void;
-  /** MediaDevices `deviceId` to use as `getUserMedia` input. `null` = system
-   *  default. Persisted across launches. */
-  inputDeviceId: string | null;
-  setInputDeviceId: (v: string | null) => void;
   tts: TtsState;
   /** Force a backend re-probe (delegates to TanStack Query refetch). */
   checkHealth: () => Promise<void>;
@@ -47,7 +43,6 @@ function useVoiceStoreLogic(): VoiceStoreValue {
   const [serverUrl, setServerUrl] = useState(DEFAULT_SERVER_URL);
   const [voice, setVoice] = useState<VoiceId>(DEFAULT_VOICE);
   const [speed, setSpeed] = useState(DEFAULT_SPEED);
-  const [inputDeviceId, setInputDeviceId] = useState<string | null>(null);
   const [tts, setTts] = useState<TtsState>({ kind: "idle" });
   const audioHandleRef = useRef<AudioHandle | null>(null);
 
@@ -67,9 +62,6 @@ function useVoiceStoreLogic(): VoiceStoreValue {
     }
     if (typeof prefs.defaultSpeed === "number") {
       setSpeed(prefs.defaultSpeed);
-    }
-    if (typeof prefs.defaultInputDeviceId === "string") {
-      setInputDeviceId(prefs.defaultInputDeviceId || null);
     }
     hydratedRef.current = true;
   }, [prefs]);
@@ -100,16 +92,6 @@ function useVoiceStoreLogic(): VoiceStoreValue {
     },
     [persistPrefs],
   );
-  const setInputDeviceIdPersist = useCallback(
-    (next: string | null) => {
-      setInputDeviceId(next);
-      // Empty string represents "system default" on the wire; renderer
-      // hydrates it back to `null`.
-      persistPrefs.mutate({ defaultInputDeviceId: next ?? "" });
-    },
-    [persistPrefs],
-  );
-
   const client = useMemo(() => new TTSClient(serverUrl), [serverUrl]);
 
   // Backend connectivity probe + voice list. Auto-fires on mount, polls every
@@ -205,8 +187,6 @@ function useVoiceStoreLogic(): VoiceStoreValue {
       setVoice: setVoicePersist,
       speed,
       setSpeed: setSpeedPersist,
-      inputDeviceId,
-      setInputDeviceId: setInputDeviceIdPersist,
       tts,
       checkHealth,
       stopAudio,
@@ -222,8 +202,6 @@ function useVoiceStoreLogic(): VoiceStoreValue {
       setVoicePersist,
       speed,
       setSpeedPersist,
-      inputDeviceId,
-      setInputDeviceIdPersist,
       tts,
       checkHealth,
       stopAudio,

--- a/apps/desktop/src/mainview/lib/voice-store.tsx
+++ b/apps/desktop/src/mainview/lib/voice-store.tsx
@@ -1,15 +1,7 @@
-import {
-  createContext,
-  useCallback,
-  useContext,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type ReactNode,
-} from "react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
 import { useMutation, useQuery } from "@tanstack/react-query";
+import { createContainer } from "@yappr/lib/unstated";
 
 import {
   buildAudio,
@@ -28,7 +20,7 @@ import { preferencesOptions, voicesOptions } from "~/lib/queries";
 import { TTSClient, type VoiceId } from "~/services/yappr";
 import type { HealthState, TtsState } from "~/types";
 
-type VoiceStoreContextValue = {
+type VoiceStoreValue = {
   serverUrl: string;
   setServerUrl: (v: string) => void;
   health: HealthState;
@@ -37,6 +29,10 @@ type VoiceStoreContextValue = {
   setVoice: (v: VoiceId) => void;
   speed: number;
   setSpeed: (v: number) => void;
+  /** MediaDevices `deviceId` to use as `getUserMedia` input. `null` = system
+   *  default. Persisted across launches. */
+  inputDeviceId: string | null;
+  setInputDeviceId: (v: string | null) => void;
   tts: TtsState;
   /** Force a backend re-probe (delegates to TanStack Query refetch). */
   checkHealth: () => Promise<void>;
@@ -47,20 +43,11 @@ type VoiceStoreContextValue = {
   transcribe: (blob: Blob) => Promise<string>;
 };
 
-const VoiceStoreContext = createContext<VoiceStoreContextValue | null>(null);
-
-export function useVoiceStore() {
-  const ctx = useContext(VoiceStoreContext);
-  if (!ctx) {
-    throw new Error("useVoiceStore must be used within VoiceStoreProvider");
-  }
-  return ctx;
-}
-
-export function VoiceStoreProvider({ children }: { children: ReactNode }) {
+function useVoiceStoreLogic(): VoiceStoreValue {
   const [serverUrl, setServerUrl] = useState(DEFAULT_SERVER_URL);
   const [voice, setVoice] = useState<VoiceId>(DEFAULT_VOICE);
   const [speed, setSpeed] = useState(DEFAULT_SPEED);
+  const [inputDeviceId, setInputDeviceId] = useState<string | null>(null);
   const [tts, setTts] = useState<TtsState>({ kind: "idle" });
   const audioHandleRef = useRef<AudioHandle | null>(null);
 
@@ -80,6 +67,9 @@ export function VoiceStoreProvider({ children }: { children: ReactNode }) {
     }
     if (typeof prefs.defaultSpeed === "number") {
       setSpeed(prefs.defaultSpeed);
+    }
+    if (typeof prefs.defaultInputDeviceId === "string") {
+      setInputDeviceId(prefs.defaultInputDeviceId || null);
     }
     hydratedRef.current = true;
   }, [prefs]);
@@ -107,6 +97,15 @@ export function VoiceStoreProvider({ children }: { children: ReactNode }) {
     (next: number) => {
       setSpeed(next);
       persistPrefs.mutate({ defaultSpeed: next });
+    },
+    [persistPrefs],
+  );
+  const setInputDeviceIdPersist = useCallback(
+    (next: string | null) => {
+      setInputDeviceId(next);
+      // Empty string represents "system default" on the wire; renderer
+      // hydrates it back to `null`.
+      persistPrefs.mutate({ defaultInputDeviceId: next ?? "" });
     },
     [persistPrefs],
   );
@@ -196,7 +195,7 @@ export function VoiceStoreProvider({ children }: { children: ReactNode }) {
     [],
   );
 
-  const value = useMemo<VoiceStoreContextValue>(
+  return useMemo<VoiceStoreValue>(
     () => ({
       serverUrl,
       setServerUrl: setServerUrlPersist,
@@ -206,6 +205,8 @@ export function VoiceStoreProvider({ children }: { children: ReactNode }) {
       setVoice: setVoicePersist,
       speed,
       setSpeed: setSpeedPersist,
+      inputDeviceId,
+      setInputDeviceId: setInputDeviceIdPersist,
       tts,
       checkHealth,
       stopAudio,
@@ -221,6 +222,8 @@ export function VoiceStoreProvider({ children }: { children: ReactNode }) {
       setVoicePersist,
       speed,
       setSpeedPersist,
+      inputDeviceId,
+      setInputDeviceIdPersist,
       tts,
       checkHealth,
       stopAudio,
@@ -228,10 +231,7 @@ export function VoiceStoreProvider({ children }: { children: ReactNode }) {
       transcribe,
     ],
   );
-
-  return (
-    <VoiceStoreContext.Provider value={value}>
-      {children}
-    </VoiceStoreContext.Provider>
-  );
 }
+
+export const { useContainer: useVoiceStore, Provider: VoiceStoreProvider } =
+  createContainer<VoiceStoreValue>(useVoiceStoreLogic);

--- a/apps/desktop/src/mainview/screens/chat/chat-layout.tsx
+++ b/apps/desktop/src/mainview/screens/chat/chat-layout.tsx
@@ -16,6 +16,7 @@ import { cn } from "~/lib/utils";
 import { SidebarInset, SidebarProvider } from "~/ui/sidebar";
 import { ChatSidebar } from "./chat-sidebar";
 import { ChatTopBar } from "./chat-top-bar";
+import { ChatStoreProvider } from "./store";
 
 interface ChatLayoutProps {
   renderMain: (props: {
@@ -72,24 +73,26 @@ export function ChatLayout({ renderMain }: ChatLayoutProps) {
   }, [models]);
 
   return (
-    <SidebarProvider>
-      <ChatSidebar
-        activeConversationId={conversationId}
-        onSelectConversation={setConversationId}
-      />
-      <SidebarInset
-        className={cn("flex h-dvh flex-col bg-background pt-8", DRAG)}
-      >
-        <ChatTopBar model={model} onModelChange={handleModelChange} />
-        <main className="min-h-0 flex-1 overflow-hidden">
-          {renderMain({
-            model,
-            onModelChange: handleModelChange,
-            conversationId,
-            onConversationChange: setConversationId,
-          })}
-        </main>
-      </SidebarInset>
-    </SidebarProvider>
+    <ChatStoreProvider>
+      <SidebarProvider>
+        <ChatSidebar
+          activeConversationId={conversationId}
+          onSelectConversation={setConversationId}
+        />
+        <SidebarInset
+          className={cn("flex h-dvh flex-col bg-background pt-8", DRAG)}
+        >
+          <ChatTopBar model={model} onModelChange={handleModelChange} />
+          <main className="min-h-0 flex-1 overflow-hidden">
+            {renderMain({
+              model,
+              onModelChange: handleModelChange,
+              conversationId,
+              onConversationChange: setConversationId,
+            })}
+          </main>
+        </SidebarInset>
+      </SidebarProvider>
+    </ChatStoreProvider>
   );
 }

--- a/apps/desktop/src/mainview/screens/chat/chat-panel.tsx
+++ b/apps/desktop/src/mainview/screens/chat/chat-panel.tsx
@@ -29,6 +29,7 @@ import {
   MessageContent,
 } from "~/ui/message";
 import { Composer } from "./composer";
+import { useChatStore } from "./store";
 
 interface ChatPanelProps {
   model: string;
@@ -100,7 +101,8 @@ export function ChatPanel({
   // every render when the query is disabled (conversationId === null) and
   // `data` stays undefined.
   const persisted = useMemo<MessageRow[]>(() => data ?? [], [data]);
-  const { tts, speak, stopAudio, transcribe, inputDeviceId } = useVoiceStore();
+  const { tts, speak, stopAudio, transcribe } = useVoiceStore();
+  const { inputDeviceId } = useChatStore();
   const isSpeaking = tts.kind === "speaking";
 
   const createConv = useMutation({

--- a/apps/desktop/src/mainview/screens/chat/chat-panel.tsx
+++ b/apps/desktop/src/mainview/screens/chat/chat-panel.tsx
@@ -100,7 +100,7 @@ export function ChatPanel({
   // every render when the query is disabled (conversationId === null) and
   // `data` stays undefined.
   const persisted = useMemo<MessageRow[]>(() => data ?? [], [data]);
-  const { tts, speak, stopAudio, transcribe } = useVoiceStore();
+  const { tts, speak, stopAudio, transcribe, inputDeviceId } = useVoiceStore();
   const isSpeaking = tts.kind === "speaking";
 
   const createConv = useMutation({
@@ -267,6 +267,7 @@ export function ChatPanel({
                   : "Loading models from Ollama…"
             }
             transcribe={transcribe}
+            inputDeviceId={inputDeviceId}
           />
         </div>
       </div>

--- a/apps/desktop/src/mainview/screens/chat/chat-settings-sheet.tsx
+++ b/apps/desktop/src/mainview/screens/chat/chat-settings-sheet.tsx
@@ -3,6 +3,7 @@ import type { ReactNode } from "react";
 import type { VoiceId } from "@yappr/sdk/schemas";
 import { formatSpeed } from "@yappr/sdk/state";
 
+import { useInputDevices } from "~/lib/audio-devices";
 import { useVoiceStore } from "~/lib/voice-store";
 import { Button } from "~/ui/button";
 import { Input } from "~/ui/input";
@@ -28,6 +29,11 @@ interface ChatSettingsSheetProps {
   children: ReactNode;
 }
 
+/** Sentinel value used by the Select to represent "use system default mic"
+ *  — radix Select disallows empty-string values, and `null` isn't a valid
+ *  Select value, so we round-trip through this stable string. */
+const INPUT_DEFAULT_SENTINEL = "__system_default__";
+
 export function ChatSettingsSheet({ children }: ChatSettingsSheetProps) {
   const {
     serverUrl,
@@ -37,9 +43,12 @@ export function ChatSettingsSheet({ children }: ChatSettingsSheetProps) {
     voices,
     speed,
     setSpeed,
+    inputDeviceId,
+    setInputDeviceId,
     health,
     checkHealth,
   } = useVoiceStore();
+  const inputDevices = useInputDevices();
 
   return (
     <Sheet>
@@ -127,6 +136,64 @@ export function ChatSettingsSheet({ children }: ChatSettingsSheetProps) {
                 )}
               </SelectContent>
             </Select>
+          </section>
+
+          <section className="space-y-2">
+            <Label
+              htmlFor="settings-input-device"
+              className="font-mono text-[0.65rem] uppercase tracking-widest text-muted-foreground"
+            >
+              Input device
+            </Label>
+            {!inputDevices.permissionGranted ? (
+              <div className="space-y-1">
+                <Button
+                  type="button"
+                  size="sm"
+                  variant="outline"
+                  onClick={() => void inputDevices.requestPermission()}
+                  className="w-full"
+                >
+                  Grant mic access
+                </Button>
+                <p className="font-mono text-[0.65rem] text-muted-foreground">
+                  macOS will prompt once; labels appear after access is granted.
+                </p>
+              </div>
+            ) : (
+              <Select
+                value={inputDeviceId ?? INPUT_DEFAULT_SENTINEL}
+                onValueChange={(v) =>
+                  setInputDeviceId(v === INPUT_DEFAULT_SENTINEL ? null : v)
+                }
+                disabled={inputDevices.devices.length === 0}
+              >
+                <SelectTrigger
+                  id="settings-input-device"
+                  aria-label="Input device"
+                  className="font-mono text-sm"
+                >
+                  <SelectValue placeholder="System default" />
+                </SelectTrigger>
+                <SelectContent translate="no" className="max-h-72">
+                  <SelectItem
+                    value={INPUT_DEFAULT_SENTINEL}
+                    className="font-mono text-sm"
+                  >
+                    System default
+                  </SelectItem>
+                  {inputDevices.devices.map((d) => (
+                    <SelectItem
+                      key={d.deviceId}
+                      value={d.deviceId}
+                      className="font-mono text-sm"
+                    >
+                      {d.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            )}
           </section>
 
           <section className="space-y-2">

--- a/apps/desktop/src/mainview/screens/chat/chat-settings-sheet.tsx
+++ b/apps/desktop/src/mainview/screens/chat/chat-settings-sheet.tsx
@@ -24,6 +24,7 @@ import {
   SheetTrigger,
 } from "~/ui/sheet";
 import { Slider } from "~/ui/slider";
+import { useChatStore } from "./store";
 
 interface ChatSettingsSheetProps {
   children: ReactNode;
@@ -43,11 +44,10 @@ export function ChatSettingsSheet({ children }: ChatSettingsSheetProps) {
     voices,
     speed,
     setSpeed,
-    inputDeviceId,
-    setInputDeviceId,
     health,
     checkHealth,
   } = useVoiceStore();
+  const { inputDeviceId, setInputDeviceId } = useChatStore();
   const inputDevices = useInputDevices();
 
   return (

--- a/apps/desktop/src/mainview/screens/chat/components/mic-button.tsx
+++ b/apps/desktop/src/mainview/screens/chat/components/mic-button.tsx
@@ -32,6 +32,8 @@ interface MicButtonProps {
   transcribe: (blob: Blob) => Promise<string>;
   /** Disable while another action (send/stop) is in flight. */
   disabled?: boolean;
+  /** MediaDevices deviceId to capture from. `null`/undefined = system default. */
+  inputDeviceId?: string | null;
 }
 
 /**
@@ -46,6 +48,7 @@ export function MicButton({
   onTranscript,
   transcribe,
   disabled,
+  inputDeviceId,
 }: MicButtonProps) {
   const [state, setState] = useState<MicState>({ kind: "idle" });
   const streamRef = useRef<MediaStream | null>(null);
@@ -57,7 +60,10 @@ export function MicButton({
 
   const start = useCallback(async () => {
     try {
-      const stream = await navigator.mediaDevices.getUserMedia({ audio: true });
+      const constraints: MediaStreamConstraints = {
+        audio: inputDeviceId ? { deviceId: { exact: inputDeviceId } } : true,
+      };
+      const stream = await navigator.mediaDevices.getUserMedia(constraints);
       streamRef.current = stream;
 
       const recorder = new MediaRecorder(stream, {
@@ -90,7 +96,7 @@ export function MicButton({
         reason: err instanceof Error ? err.message : "Mic unavailable",
       });
     }
-  }, []);
+  }, [inputDeviceId]);
 
   const stop = useCallback(async () => {
     if (state.kind !== "recording") return;

--- a/apps/desktop/src/mainview/screens/chat/composer.tsx
+++ b/apps/desktop/src/mainview/screens/chat/composer.tsx
@@ -39,6 +39,8 @@ export type ComposerProps = {
   /** When provided, surfaces a mic button that records audio and appends the
    *  transcript to the current draft. Pass the voice store's `transcribe`. */
   transcribe?: (blob: Blob) => Promise<string>;
+  /** Forwarded to MicButton's `getUserMedia` constraint. */
+  inputDeviceId?: string | null;
 };
 
 /**
@@ -54,6 +56,7 @@ export function Composer({
   disabled,
   placeholder,
   transcribe,
+  inputDeviceId,
 }: ComposerProps) {
   const [draft, setDraft] = useState("");
   const [pendingFiles, setPendingFiles] = useState<FileUIPart[]>([]);
@@ -180,6 +183,7 @@ export function Composer({
                   onTranscript={appendTranscript}
                   transcribe={transcribe}
                   disabled={isBusy || disabled}
+                  inputDeviceId={inputDeviceId}
                 />
               ) : null}
               {leadingSlot}

--- a/apps/desktop/src/mainview/screens/chat/store.tsx
+++ b/apps/desktop/src/mainview/screens/chat/store.tsx
@@ -1,0 +1,64 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+
+import { useMutation, useQuery } from "@tanstack/react-query";
+import { createContainer } from "@yappr/lib/unstated";
+
+import { dbRpc } from "~/lib/db-rpc";
+import { preferencesOptions } from "~/lib/queries";
+
+/**
+ * Chat-feature container — colocated with the screen it powers, mirroring
+ * the CLI's per-screen store layout (apps/cli/src/screens/[name]/store.tsx).
+ * Owns chat-only state that should not leak into the cross-screen voice
+ * runtime (TTS/STT/health).
+ *
+ * Today: the selected MediaDevices deviceId for dictation. Future: draft,
+ * active conversation, file uploads, etc. can migrate in.
+ */
+export interface ChatStoreValue {
+  /** MediaDevices `deviceId` to use as `getUserMedia` input. `null` = system
+   *  default. Persisted to the `defaultInputDeviceId` preference key. */
+  inputDeviceId: string | null;
+  setInputDeviceId: (v: string | null) => void;
+}
+
+function useChatStoreLogic(): ChatStoreValue {
+  const [inputDeviceId, setInputDeviceId] = useState<string | null>(null);
+
+  const { data: prefs } = useQuery(preferencesOptions);
+  const hydratedRef = useRef(false);
+  useEffect(() => {
+    if (!prefs || hydratedRef.current) return;
+    if (typeof prefs.defaultInputDeviceId === "string") {
+      // Empty string round-trips as "system default" (null on the renderer
+      // side). See `setInputDeviceIdPersist` below for the inverse.
+      // eslint-disable-next-line react-hooks/set-state-in-effect
+      setInputDeviceId(prefs.defaultInputDeviceId || null);
+    }
+    hydratedRef.current = true;
+  }, [prefs]);
+
+  const persistPrefs = useMutation({
+    mutationFn: (entries: Record<string, unknown>) =>
+      dbRpc.request("preferences:setMany", entries),
+  });
+
+  const setInputDeviceIdPersist = useCallback(
+    (next: string | null) => {
+      setInputDeviceId(next);
+      persistPrefs.mutate({ defaultInputDeviceId: next ?? "" });
+    },
+    [persistPrefs],
+  );
+
+  return useMemo<ChatStoreValue>(
+    () => ({
+      inputDeviceId,
+      setInputDeviceId: setInputDeviceIdPersist,
+    }),
+    [inputDeviceId, setInputDeviceIdPersist],
+  );
+}
+
+export const { useContainer: useChatStore, Provider: ChatStoreProvider } =
+  createContainer<ChatStoreValue>(useChatStoreLogic);

--- a/bun.lock
+++ b/bun.lock
@@ -72,6 +72,7 @@
         "@tanstack/react-query": "^5.100.10",
         "@tanstack/react-router": "^1.169.2",
         "@yappr/db": "workspace:*",
+        "@yappr/lib": "workspace:*",
         "@yappr/sdk": "workspace:*",
         "ai": "^6.0.177",
         "class-variance-authority": "^0.7.1",
@@ -1990,6 +1991,8 @@
 
     "@typescript-eslint/visitor-keys/eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
 
+    "@yappr/desktop/@types/bun": ["@types/bun@1.3.14", "", { "dependencies": { "bun-types": "1.3.14" } }, "sha512-h1hFqFVcvAvD9j9K7ZW7vd82aSA+rTdznZa+5bwvCwqSB1jmmfLcbIWhOLx1/+boy/xmjgCs/OMUL8hRJSmnPw=="],
+
     "ajv-formats/ajv": ["ajv@8.17.1", "", { "dependencies": { "fast-deep-equal": "^3.1.3", "fast-uri": "^3.0.1", "json-schema-traverse": "^1.0.0", "require-from-string": "^2.0.2" } }, "sha512-B/gBuNg5SiMTrPkC+A2+cW0RszwxYmn6VYxB/inlBStS5nx6xHIt/ehKRhIMhqusl7a8LjQoZnjCs5vhwxOQ1g=="],
 
     "anymatch/picomatch": ["picomatch@2.3.2", "", {}, "sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA=="],
@@ -2163,6 +2166,8 @@
     "@typescript-eslint/typescript-estree/minimatch/brace-expansion": ["brace-expansion@5.0.6", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g=="],
 
     "@typescript-eslint/typescript-estree/tinyglobby/picomatch": ["picomatch@4.0.3", "", {}, "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q=="],
+
+    "@yappr/desktop/@types/bun/bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
     "ajv-formats/ajv/json-schema-traverse": ["json-schema-traverse@1.0.0", "", {}, "sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug=="],
 


### PR DESCRIPTION
## Summary

Two related changes that ride together because both touch `voice-store.tsx`.

### Input-device picker

Adds an "Input device" section to the chat settings sheet, backed by `navigator.mediaDevices.enumerateDevices()`. The selected `deviceId` persists to the shared preferences KV (`defaultInputDeviceId`) and is threaded through `MicButton.getUserMedia` so dictation captures from the chosen mic.

Motivation: hitting *"Silent input (rms 0.001) — mic muted or no speech"* on a stale or muted system default. Letting the user pin the device fixes it without lowering the silence threshold.

Permission gate: until the user grants mic access at least once, the browser returns empty labels, so the picker hides itself behind a **Grant mic access** button that calls `getUserMedia` and re-enumerates on success.

Async device enumeration uses TanStack Query with a `devicechange`-event invalidation listener (per the repo's "async via @tanstack/react-query" convention).

### Voice store → createContainer

`voice-store.tsx` switches from hand-rolled `createContext + useContext + throw-if-empty` to the `@yappr/lib/unstated.createContainer` pattern already used by the CLI's chat/voices/settings stores. `useVoiceStore` and `VoiceStoreProvider` keep their names so every call site stays unchanged. Adds `@yappr/lib` as a workspace dep on desktop.

## Files
- `apps/desktop/package.json`, `bun.lock` — add `@yappr/lib` dep
- `apps/desktop/src/mainview/lib/voice-store.tsx` — createContainer refactor + new `inputDeviceId` state + persisted setter
- `apps/desktop/src/mainview/lib/audio-devices.ts` — new `useInputDevices` hook (TanStack Query)
- `apps/desktop/src/mainview/screens/chat/chat-settings-sheet.tsx` — new Input Device section
- `apps/desktop/src/mainview/screens/chat/components/mic-button.tsx` — accepts `inputDeviceId` prop, passes to `getUserMedia`
- `apps/desktop/src/mainview/screens/chat/composer.tsx`, `chat-panel.tsx` — thread the deviceId

## Test plan
- [x] `bun run check` (format + lint + typecheck + 38 tests pass)
- [ ] Manual: `bun run desktop` (HMR) — open settings, click **Grant mic access**, pick a non-default mic, dictate; transcription should succeed
- [ ] Manual: unplug the chosen mic, settings refreshes via `devicechange`, picker falls back to whatever remains
- [ ] Manual: relaunch app — selected device is restored from `~/.yappr/yappr.db`

Output-device picker not included — `HTMLAudioElement.setSinkId` isn't part of WebKit's stable API and the macOS Electrobun renderer uses WebKit. Worth probing separately.