### PR TITLE
feat(chat): per-turn telemetry — tokens, latency, cost

### DIFF
--- a/apps/cli/src/screens/chat/screen.tsx
+++ b/apps/cli/src/screens/chat/screen.tsx
@@ -1,5 +1,7 @@
 import { Box, Text } from "ink";
 
+import { formatTelemetry } from "@yappr/lib/telemetry";
+
 import { Footer, Header } from "~/components";
 import { useKeyboard, useTerminalWidth } from "~/hooks";
 import { truncateDisplayWidth } from "~/string-display.js";
@@ -94,6 +96,12 @@ export function ChatScreen({ onBack, onNavigate }: ChatScreenProps) {
             </Text>
           ))}
           <Text dimColor>ctrl+x clears all attachments</Text>
+        </Box>
+      )}
+
+      {!state.isEventStreamOpen && state.telemetry !== null && (
+        <Box marginBottom={1}>
+          <Text dimColor>{formatTelemetry(state.telemetry)}</Text>
         </Box>
       )}
 

--- a/apps/cli/src/screens/chat/store.tsx
+++ b/apps/cli/src/screens/chat/store.tsx
@@ -6,6 +6,7 @@ import {
   parseImageTokens,
 } from "@yappr/lib/image-path";
 import { markdownToNarrationText } from "@yappr/lib/narration-text";
+import type { TurnTelemetry } from "@yappr/lib/telemetry";
 import { okAsync } from "neverthrow";
 
 import { buildChatFooterItems } from "~/footer-items.js";
@@ -80,6 +81,7 @@ export function useChatController(initialState?: ChatStoreInitialState) {
   const [isEventStreamOpen, setIsEventStreamOpen] = useState(false);
   const [hasStoppedRecording, setHasStoppedRecording] = useState(false);
   const [pendingAttachments, setPendingAttachments] = useState<string[]>([]);
+  const [telemetry, setTelemetry] = useState<TurnTelemetry | null>(null);
   const abortRef = useRef<AbortController | null>(null);
   const chatAbortRef = useRef<AbortController | null>(null);
   const runStartedAtRef = useRef(0);
@@ -195,6 +197,7 @@ export function useChatController(initialState?: ChatStoreInitialState) {
     })();
     void persistUser;
 
+    setTelemetry(null);
     return chat(prompt, {
       provider,
       model,
@@ -203,6 +206,7 @@ export function useChatController(initialState?: ChatStoreInitialState) {
       mcpConfigPath,
       messages: priorMessages,
       images,
+      onTelemetry: setTelemetry,
       onUpdate: (text) => {
         if (firstTokenAtRef.current === null)
           firstTokenAtRef.current = Date.now();
@@ -695,6 +699,7 @@ export function useChatController(initialState?: ChatStoreInitialState) {
     statusContent,
     slashNotice,
     pendingAttachments,
+    telemetry,
     footerItems: buildChatFooterItems({
       isSlashPalette,
       isChatPending: chatMutation.isPending,

--- a/apps/cli/src/services/yappr/chat/adapters/ollama-transport.ts
+++ b/apps/cli/src/services/yappr/chat/adapters/ollama-transport.ts
@@ -51,6 +51,17 @@ export function createOllamaChatTransport(
             type: "error",
             message: chunk.error?.message ?? "Chat stream error",
           };
+        } else if (chunk.type === "RUN_FINISHED" && chunk.usage) {
+          const u = chunk.usage;
+          yield {
+            type: "usage",
+            usage: {
+              promptTokens: u.promptTokens,
+              completionTokens: u.completionTokens,
+              totalTokens: u.totalTokens,
+              ...(typeof u.cost === "number" ? { cost: u.cost } : {}),
+            },
+          };
         }
       }
     },

--- a/apps/cli/src/services/yappr/chat/adapters/openrouter-transport.ts
+++ b/apps/cli/src/services/yappr/chat/adapters/openrouter-transport.ts
@@ -54,6 +54,8 @@ export function createOpenRouterChatTransport(
           };
         } else if (chunk.type === "content" && chunk.delta) {
           yield { type: "delta", text: chunk.delta };
+        } else if (chunk.type === "usage") {
+          yield { type: "usage", usage: chunk.usage };
         }
       }
     },

--- a/apps/cli/src/services/yappr/chat/session.ts
+++ b/apps/cli/src/services/yappr/chat/session.ts
@@ -1,5 +1,7 @@
 import { toError } from "@yappr/lib/result";
+import type { TurnTelemetry } from "@yappr/lib/telemetry";
 import { ResultAsync } from "neverthrow";
+import { match } from "ts-pattern";
 
 import { MCP_CONFIG_PATH } from "../../../constants.js";
 import type { ChatOptions } from "../../../types.js";
@@ -42,6 +44,7 @@ export function chat(
     systemPrompts = [],
     abortController,
     onToolCall,
+    onTelemetry,
     runtime = defaultChatRuntime,
   } = options;
 
@@ -64,7 +67,7 @@ export function chat(
         ...(abortController && { signal: abortController.signal }),
       };
       return ResultAsync.fromPromise(
-        drainStream(transport, req, { onUpdate, onToolCall }, mcp),
+        drainStream(transport, req, { onUpdate, onToolCall, onTelemetry }, mcp),
         toError,
       );
     });
@@ -73,6 +76,7 @@ export function chat(
 interface ChatCallbacks {
   onUpdate: ChatOptions["onUpdate"];
   onToolCall: ChatOptions["onToolCall"];
+  onTelemetry: ChatOptions["onTelemetry"];
 }
 
 async function drainStream(
@@ -82,25 +86,32 @@ async function drainStream(
   mcp: { close: () => Promise<void> },
 ): Promise<string | null> {
   let finalContent = "";
+  let usage: Omit<TurnTelemetry, "latencyMs"> | null = null;
+  const startedAt = Date.now();
   try {
     for await (const event of transport.stream(req)) {
       throwIfAborted(req.signal);
-      switch (event.type) {
-        case "delta": {
-          finalContent += event.text;
-          callbacks.onUpdate?.(finalContent);
-          break;
-        }
-        case "tool": {
-          callbacks.onToolCall?.(event.name, event.phase);
-          break;
-        }
-        case "error": {
-          throw new Error(event.message);
-        }
+      // Usage is captured outside the match so control-flow analysis can
+      // narrow `usage` after the loop (closure writes are invisible to CFA).
+      if (event.type === "usage") {
+        usage = event.usage;
+        continue;
       }
+      match(event)
+        .with({ type: "delta" }, (e) => {
+          finalContent += e.text;
+          callbacks.onUpdate?.(finalContent);
+        })
+        .with({ type: "tool" }, (e) => callbacks.onToolCall?.(e.name, e.phase))
+        .with({ type: "error" }, (e) => {
+          throw new Error(e.message);
+        })
+        .exhaustive();
     }
     throwIfAborted(req.signal);
+    if (usage) {
+      callbacks.onTelemetry?.({ ...usage, latencyMs: Date.now() - startedAt });
+    }
     return finalContent || null;
   } finally {
     await mcp.close();

--- a/apps/cli/src/services/yappr/chat/transport.ts
+++ b/apps/cli/src/services/yappr/chat/transport.ts
@@ -1,4 +1,5 @@
 import type { ModelMessage, SchemaInput, Tool } from "@tanstack/ai";
+import type { TurnTelemetry } from "@yappr/lib/telemetry";
 import { match } from "ts-pattern";
 
 import type { ChatProvider } from "../../../types.js";
@@ -25,6 +26,7 @@ export interface ChatStreamRequest {
 export type ChatStreamEvent =
   | { type: "delta"; text: string }
   | { type: "tool"; phase: "start" | "end"; name: string }
+  | { type: "usage"; usage: Omit<TurnTelemetry, "latencyMs"> }
   | { type: "error"; message: string };
 
 export interface ChatTransport {

--- a/apps/cli/src/services/yappr/openrouter.ts
+++ b/apps/cli/src/services/yappr/openrouter.ts
@@ -51,8 +51,17 @@ interface OpenRouterStreamChoice {
   delta?: OpenRouterStreamDelta;
 }
 
+interface OpenRouterUsagePayload {
+  prompt_tokens?: number;
+  completion_tokens?: number;
+  total_tokens?: number;
+  /** OpenRouter-reported cost in USD (present when usage accounting is on). */
+  cost?: number;
+}
+
 interface OpenRouterStreamLinePayload {
   choices?: OpenRouterStreamChoice[];
+  usage?: OpenRouterUsagePayload;
 }
 
 interface OpenRouterCompletionMessageBody {
@@ -73,7 +82,16 @@ interface OpenRouterRunErrorBody {
 
 type OpenRouterStreamChunk =
   | { type: "RUN_ERROR"; error: OpenRouterRunErrorBody }
-  | { type: "content"; delta: string; content: string };
+  | { type: "content"; delta: string; content: string }
+  | {
+      type: "usage";
+      usage: {
+        promptTokens: number;
+        completionTokens: number;
+        totalTokens: number;
+        cost?: number;
+      };
+    };
 
 interface OpenRouterChatAdapter {
   name: "openrouter";
@@ -154,6 +172,8 @@ export function createOpenRouterChat(
           content: m.content,
         })),
         stream: true,
+        // Ask OpenRouter to append a final usage chunk (tokens + cost).
+        usage: { include: true },
       };
       const res = await fetch(`${OPENROUTER_BASE}/chat/completions`, {
         method: "POST",
@@ -193,6 +213,18 @@ export function createOpenRouterChat(
                     type: "content",
                     delta,
                     content: accumulated,
+                  };
+                }
+                if (json.usage) {
+                  const u = json.usage;
+                  yield {
+                    type: "usage",
+                    usage: {
+                      promptTokens: u.prompt_tokens ?? 0,
+                      completionTokens: u.completion_tokens ?? 0,
+                      totalTokens: u.total_tokens ?? 0,
+                      ...(typeof u.cost === "number" ? { cost: u.cost } : {}),
+                    },
                   };
                 }
               } catch {

--- a/apps/cli/src/types.ts
+++ b/apps/cli/src/types.ts
@@ -1,3 +1,4 @@
+import type { TurnTelemetry } from "@yappr/lib/telemetry";
 import type { VoiceConfig, VoiceReference } from "@yappr/sdk/schemas";
 
 import type { ChatRuntime } from "./services/yappr/chat/runtime.js";
@@ -89,5 +90,7 @@ export interface ChatOptions {
   abortController?: AbortController;
   /** Called when an MCP tool call starts or ends (for UI status). */
   onToolCall?: (name: string, phase: "start" | "end") => void;
+  /** Called once per turn with token + latency stats when the stream reports usage. */
+  onTelemetry?: (telemetry: TurnTelemetry) => void;
   runtime?: ChatRuntime;
 }

--- a/apps/desktop/src/mainview/app/screens/chat/components/panel.tsx
+++ b/apps/desktop/src/mainview/app/screens/chat/components/panel.tsx
@@ -1,6 +1,7 @@
 import { memo, useEffect, useRef, useState } from "react";
 
 import { useSelector } from "@tanstack/react-store";
+import { formatTelemetry } from "@yappr/lib/telemetry";
 import {
   AlertTriangle,
   Copy,
@@ -129,6 +130,11 @@ export function ChatPanel() {
         className="border-t border-border bg-background/95 p-4 backdrop-blur supports-[backdrop-filter]:bg-background/70"
       >
         <div className="mx-auto max-w-3xl">
+          {session.telemetry && !session.isBusy ? (
+            <div className="mb-1 text-center font-mono text-[10px] tracking-wide text-foil-mute">
+              {formatTelemetry(session.telemetry)}
+            </div>
+          ) : null}
           <Composer
             onSend={(t, f) => void session.submit(t, f)}
             isBusy={session.isBusy}

--- a/apps/desktop/src/mainview/app/screens/chat/store.tsx
+++ b/apps/desktop/src/mainview/app/screens/chat/store.tsx
@@ -1,4 +1,11 @@
-import { useCallback, useEffect, useMemo, useRef, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type ReactNode,
+} from "react";
 
 import { useChat, type UIMessage } from "@tanstack/ai-react";
 import { useQuery, useQueryClient } from "@tanstack/react-query";
@@ -9,6 +16,7 @@ import {
 } from "@tanstack/react-store";
 import type { Store } from "@tanstack/store";
 import type { MessageRow } from "@yappr/db/rpc";
+import type { TurnTelemetry } from "@yappr/lib/telemetry";
 
 import {
   attachmentToPart,
@@ -164,6 +172,8 @@ export interface ChatSession {
   showLoading: boolean;
   modelReady: boolean;
   modelsLoaded: boolean;
+  /** Stats for the most recent completed turn; null until the first reply. */
+  telemetry: TurnTelemetry | null;
   submit: (text: string, files: Attachment[]) => Promise<void>;
   regenerateMessage: (messageId: string) => Promise<void>;
   stop: () => void;
@@ -191,6 +201,12 @@ export function useChatSession(): ChatSession {
   const liveConvIdRef = useRef<string | null>(conversationId);
   const persistedMessageIdsRef = useRef(new Map<string, string>());
   const pendingRegenerateMessageIdRef = useRef<string | null>(null);
+
+  // Per-turn telemetry: usage captured from the RUN_FINISHED chunk, latency
+  // measured from send to finish. Cleared at send so stale stats don't linger.
+  const [telemetry, setTelemetry] = useState<TurnTelemetry | null>(null);
+  const sentAtRef = useRef<number | null>(null);
+  const usageRef = useRef<Omit<TurnTelemetry, "latencyMs"> | null>(null);
   useEffect(() => {
     persistedMessageIdsRef.current = new Map(
       persisted.map((m) => [m.id, m.id]),
@@ -212,7 +228,24 @@ export function useChatSession(): ChatSession {
   const { messages, reload, sendMessage, status, error, setMessages, stop } =
     useChat({
       connection,
+      onChunk: (chunk) => {
+        if (chunk.type === "RUN_FINISHED" && chunk.usage) {
+          const u = chunk.usage;
+          usageRef.current = {
+            promptTokens: u.promptTokens,
+            completionTokens: u.completionTokens,
+            totalTokens: u.totalTokens,
+            ...(typeof u.cost === "number" ? { cost: u.cost } : {}),
+          };
+        }
+      },
       onFinish: async (message) => {
+        if (usageRef.current) {
+          const latencyMs = sentAtRef.current
+            ? Date.now() - sentAtRef.current
+            : 0;
+          setTelemetry({ ...usageRef.current, latencyMs });
+        }
         const regeneratedMessageId = pendingRegenerateMessageIdRef.current;
         pendingRegenerateMessageIdRef.current = null;
         const convId = liveConvIdRef.current;
@@ -281,6 +314,9 @@ export function useChatSession(): ChatSession {
         content: userRowContent(text, files),
         partsJson,
       });
+      sentAtRef.current = Date.now();
+      usageRef.current = null;
+      setTelemetry(null);
       await (files.length > 0
         ? sendMessage({ content: parts })
         : sendMessage(text.trim()));
@@ -294,6 +330,9 @@ export function useChatSession(): ChatSession {
       pendingRegenerateMessageIdRef.current = store.state.conversationId
         ? (persistedMessageIdsRef.current.get(messageId) ?? messageId)
         : null;
+      sentAtRef.current = Date.now();
+      usageRef.current = null;
+      setTelemetry(null);
       try {
         await reload();
       } catch {
@@ -311,6 +350,7 @@ export function useChatSession(): ChatSession {
     showLoading,
     modelReady,
     modelsLoaded: Boolean(models),
+    telemetry,
     submit,
     regenerateMessage,
     stop,

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -11,7 +11,8 @@
   "exports": {
     "./image-path": "./src/image-path.ts",
     "./narration-text": "./src/narration-text.ts",
-    "./result": "./src/result.ts"
+    "./result": "./src/result.ts",
+    "./telemetry": "./src/telemetry.ts"
   },
   "dependencies": {
     "marked": "^18.0.3"

--- a/packages/lib/src/telemetry.test.ts
+++ b/packages/lib/src/telemetry.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "bun:test";
+
+import { formatTelemetry } from "./telemetry.js";
+
+describe("formatTelemetry", () => {
+  it("shows tokens, latency, and tokens/sec for local turns (no cost)", () => {
+    expect(
+      formatTelemetry({
+        promptTokens: 8,
+        completionTokens: 20,
+        totalTokens: 28,
+        latencyMs: 1000,
+      }),
+    ).toBe("↑8 ↓20 · 1.0s · 20 tok/s");
+  });
+
+  it("shows cost instead of tokens/sec when the provider reports it", () => {
+    expect(
+      formatTelemetry({
+        promptTokens: 8,
+        completionTokens: 23,
+        totalTokens: 31,
+        latencyMs: 623,
+        cost: 0.000_146,
+      }),
+    ).toBe("↑8 ↓23 · 623ms · $0.0001");
+  });
+
+  it("omits tokens/sec when no completion tokens were produced", () => {
+    expect(
+      formatTelemetry({
+        promptTokens: 5,
+        completionTokens: 0,
+        totalTokens: 5,
+        latencyMs: 200,
+      }),
+    ).toBe("↑5 ↓0 · 200ms");
+  });
+});

--- a/packages/lib/src/telemetry.ts
+++ b/packages/lib/src/telemetry.ts
@@ -1,0 +1,33 @@
+/** Per-turn chat telemetry, derived from the stream's final usage + timing. */
+export interface TurnTelemetry {
+  promptTokens: number;
+  completionTokens: number;
+  totalTokens: number;
+  /** End-to-end latency of the turn, in milliseconds. */
+  latencyMs: number;
+  /** Provider-reported cost in USD, when available (cloud providers). */
+  cost?: number;
+}
+
+const formatLatency = (ms: number): string =>
+  ms < 1000 ? `${Math.round(ms)}ms` : `${(ms / 1000).toFixed(1)}s`;
+
+/**
+ * Compact one-line stats string for after an assistant reply, e.g.
+ * `↑8 ↓23 · 1.2s · 19 tok/s` (local) or `↑8 ↓23 · 1.2s · $0.0001` (cloud).
+ * Shows cost when the provider reports it, otherwise tokens/sec.
+ */
+export function formatTelemetry(t: TurnTelemetry): string {
+  const parts = [
+    `↑${t.promptTokens} ↓${t.completionTokens}`,
+    formatLatency(t.latencyMs),
+  ];
+  if (typeof t.cost === "number" && t.cost > 0) {
+    parts.push(`$${t.cost.toFixed(4)}`);
+  } else if (t.completionTokens > 0 && t.latencyMs > 0) {
+    parts.push(
+      `${Math.round(t.completionTokens / (t.latencyMs / 1000))} tok/s`,
+    );
+  }
+  return parts.join(" · ");
+}


### PR DESCRIPTION
Closes #13.

Compact stats line after each assistant reply, both surfaces, from the chat stream — no extra request.

## What
- `@yappr/lib/telemetry`: `TurnTelemetry` + `formatTelemetry` — `↑8 ↓23 · 1.2s · 19 tok/s` (local) / `· $0.0001` (cloud). Unit-tested.
- Capture point: the `RUN_FINISHED` usage chunk (`TokenUsage`); latency measured around the turn.
- **CLI**: new `usage` `ChatStreamEvent` + `onTelemetry` option; `drainStream` matches the stream union exhaustively (`ts-pattern`) and reports telemetry; the chat screen renders a dim line above the composer.
- **OpenRouter**: opts into usage accounting (`usage: { include: true }`) and the SSE parse emits a usage chunk carrying tokens + `cost`.
- **Desktop**: `useChatSession` captures usage via `useChat` `onChunk` + latency; panel renders the line under the composer.

## Conventions
neverthrow / ts-pattern / zod stack preserved (alanstack). No new deps.

## Verification
- `bun run check` green: format · lint (5/5) · typecheck (5/5) · **87 tests** (3 new for `formatTelemetry`).
- `vite build` (desktop) compiles.
- ⚠️ Not yet click-tested live — local turns (Ollama tokens/sec) verifiable in `bun run tui` / `bun run desktop`; OpenRouter cost needs a key.

## Note
`#14` (agent loop) is the other AFK-ready issue. `@onrails` adoption is intentionally **not** done here — see PR discussion / it's a repo-wide stack migration, not a feature slice.