### PR TITLE
feat(lib): Effect migration foundation — bridges + ADR

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -20,6 +20,7 @@
     "@yappr/lib": "workspace:*",
     "@yappr/sdk": "workspace:*",
     "cli-highlight": "^2.1.11",
+    "effect": "^3.21.4",
     "ink": "^7.0.3",
     "ink-spinner": "^5.0.0",
     "ink-text-input": "^6.0.0",

--- a/apps/cli/src/services/yappr/chat/session-effect.test.ts
+++ b/apps/cli/src/services/yappr/chat/session-effect.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "bun:test";
+import { Effect, Exit } from "effect";
+import { okAsync } from "neverthrow";
+
+import type { ChatRuntime } from "./runtime.js";
+import { acquireMcp, ChatRuntimeTag } from "./session-effect.js";
+
+function fakeRuntime(closed: { value: boolean }): ChatRuntime {
+  const mcp = {
+    loadConfigAndGetStatuses: () => okAsync([]),
+    getTanStackTools: () => [],
+    close: () => {
+      closed.value = true;
+      return Promise.resolve();
+    },
+  };
+  // ponytail: acquireMcp only touches createMcpManager; the rest of the
+  // ChatRuntime surface is irrelevant to this resource-lifecycle test.
+  return { createMcpManager: () => mcp } as unknown as ChatRuntime;
+}
+
+describe("acquireMcp (Effect Scope)", () => {
+  it("closes the MCP manager even when the scoped program fails", async () => {
+    const closed = { value: false };
+    const program = Effect.scoped(
+      Effect.gen(function* () {
+        yield* acquireMcp("x");
+        return yield* Effect.fail(new Error("boom"));
+      }),
+    ).pipe(Effect.provideService(ChatRuntimeTag, fakeRuntime(closed)));
+
+    const exit = await Effect.runPromiseExit(program);
+
+    expect(Exit.isFailure(exit)).toBe(true);
+    expect(closed.value).toBe(true); // released despite the failure
+  });
+
+  it("closes the MCP manager on success", async () => {
+    const closed = { value: false };
+    const program = Effect.scoped(acquireMcp("x")).pipe(
+      Effect.provideService(ChatRuntimeTag, fakeRuntime(closed)),
+    );
+
+    await Effect.runPromise(program);
+
+    expect(closed.value).toBe(true);
+  });
+});

--- a/apps/cli/src/services/yappr/chat/session-effect.ts
+++ b/apps/cli/src/services/yappr/chat/session-effect.ts
@@ -1,0 +1,178 @@
+import { toError } from "@yappr/lib/result";
+import type { TurnTelemetry } from "@yappr/lib/telemetry";
+import { Cause, Context, Effect, Exit, Ref, Stream } from "effect";
+import {
+  errAsync,
+  okAsync,
+  ResultAsync,
+  type ResultAsync as RA,
+} from "neverthrow";
+import { match } from "ts-pattern";
+
+import { MCP_CONFIG_PATH } from "../../../constants.js";
+import type { ChatOptions } from "../../../types.js";
+import { buildChatModelMessages } from "./messages.js";
+import { defaultChatRuntime, type ChatRuntime } from "./runtime.js";
+import { createChatTransport, type ChatStreamRequest } from "./transport.js";
+
+/**
+ * SPIKE: the `chat()` orchestration re-expressed as an Effect program, to
+ * evaluate the fit of Effect as a stricter FP idiom. Demonstrates the three
+ * wins claimed for the service core:
+ *   - Layer/DI:      `ChatRuntime` becomes a typed dependency (no `runtime` param).
+ *   - Scope:         the MCP manager is `acquireRelease`d — close() is guaranteed
+ *                    on success, failure, AND interruption (vs manual try/finally).
+ *   - Interruption:  abort is structured (race + interrupt) — no `throwIfAborted`
+ *                    threaded through the drain.
+ * Kept behind a `ResultAsync` boundary so callers are identical to `chat()`.
+ * Parallel to session.ts; not wired into the UI.
+ */
+
+class ChatRuntimeTag extends Context.Tag("ChatRuntime")<
+  ChatRuntimeTag,
+  ChatRuntime
+>() {}
+
+/** neverthrow → Effect boundary adapter. */
+const fromResultAsync = <A, E>(ra: RA<A, E>): Effect.Effect<A, E> =>
+  Effect.promise(() => Promise.resolve(ra)).pipe(
+    Effect.flatMap((res) =>
+      res.match(
+        (a) => Effect.succeed(a),
+        (e) => Effect.fail(e),
+      ),
+    ),
+  );
+
+/** MCP manager as a scoped resource: load on acquire, close on scope exit. */
+const acquireMcp = (configPath: string) =>
+  Effect.gen(function* () {
+    const runtime = yield* ChatRuntimeTag;
+    const mcp = runtime.createMcpManager();
+    return yield* Effect.acquireRelease(
+      fromResultAsync(mcp.loadConfigAndGetStatuses(configPath)).pipe(
+        Effect.as(mcp),
+      ),
+      () => Effect.promise(() => mcp.close()),
+    );
+  });
+
+/** Interrupt the running fiber when an external AbortSignal fires. */
+const interruptOnAbort = (signal: AbortSignal | undefined) =>
+  signal === undefined
+    ? Effect.never
+    : Effect.async<never>((resume) => {
+        const onAbort = () => resume(Effect.interrupt);
+        if (signal.aborted) onAbort();
+        else signal.addEventListener("abort", onAbort, { once: true });
+      });
+
+interface DrainCallbacks {
+  onUpdate: ChatOptions["onUpdate"];
+  onToolCall: ChatOptions["onToolCall"];
+  onTelemetry: ChatOptions["onTelemetry"];
+}
+
+const drain = (
+  transport: ReturnType<typeof createChatTransport>,
+  req: ChatStreamRequest,
+  callbacks: DrainCallbacks,
+  startedAt: number,
+) =>
+  Effect.gen(function* () {
+    const content = yield* Ref.make("");
+    const usage = yield* Ref.make<Omit<TurnTelemetry, "latencyMs"> | null>(
+      null,
+    );
+
+    yield* Stream.fromAsyncIterable(transport.stream(req), toError).pipe(
+      Stream.runForEach((event) =>
+        match(event)
+          .with({ type: "delta" }, (e) =>
+            Ref.updateAndGet(content, (c) => c + e.text).pipe(
+              Effect.flatMap((c) => Effect.sync(() => callbacks.onUpdate?.(c))),
+            ),
+          )
+          .with({ type: "tool" }, (e) =>
+            Effect.sync(() => callbacks.onToolCall?.(e.name, e.phase)),
+          )
+          .with({ type: "usage" }, (e) => Ref.set(usage, e.usage))
+          .with({ type: "error" }, (e) => Effect.fail(new Error(e.message)))
+          .exhaustive(),
+      ),
+    );
+
+    const finalUsage = yield* Ref.get(usage);
+    if (finalUsage) {
+      yield* Effect.sync(() =>
+        callbacks.onTelemetry?.({
+          ...finalUsage,
+          latencyMs: Date.now() - startedAt,
+        }),
+      );
+    }
+    const finalContent = yield* Ref.get(content);
+    return finalContent || null;
+  });
+
+const chatProgram = (prompt: string, options: ChatOptions) =>
+  Effect.gen(function* () {
+    const {
+      provider = "ollama",
+      model = "qwen2.5:14b",
+      ollamaBaseUrl,
+      openrouterApiKey,
+      mcpConfigPath,
+      useTools = true,
+      messages: priorMessages = [],
+      images = [],
+      systemPrompts = [],
+      abortController,
+      onUpdate,
+      onToolCall,
+      onTelemetry,
+    } = options;
+
+    const runtime = yield* ChatRuntimeTag;
+    const mcp = yield* acquireMcp(mcpConfigPath ?? MCP_CONFIG_PATH);
+    const transport = createChatTransport(runtime, {
+      provider,
+      model,
+      ollamaBaseUrl,
+      openrouterApiKey,
+    });
+    const req: ChatStreamRequest = {
+      messages: buildChatModelMessages(prompt, priorMessages, images),
+      systemPrompts,
+      tools: useTools ? mcp.getTanStackTools() : [],
+      ...(abortController && { signal: abortController.signal }),
+    };
+
+    return yield* Effect.raceFirst(
+      drain(transport, req, { onUpdate, onToolCall, onTelemetry }, Date.now()),
+      interruptOnAbort(abortController?.signal),
+    );
+  });
+
+/** Drop-in equivalent of `chat()` — runs the Effect and maps Exit → Result. */
+export function chatEffect(
+  prompt: string,
+  options: ChatOptions = {},
+): ResultAsync<string | null, Error> {
+  const program = chatProgram(prompt, options).pipe(
+    Effect.scoped,
+    Effect.provideService(
+      ChatRuntimeTag,
+      options.runtime ?? defaultChatRuntime,
+    ),
+  );
+  return ResultAsync.fromSafePromise(Effect.runPromiseExit(program)).andThen(
+    (exit) =>
+      Exit.match(exit, {
+        onSuccess: (value) => okAsync(value),
+        onFailure: (cause) => errAsync(toError(Cause.squash(cause))),
+      }),
+  );
+}
+
+export { ChatRuntimeTag, acquireMcp };

--- a/bun.lock
+++ b/bun.lock
@@ -37,6 +37,7 @@
         "@yappr/lib": "workspace:*",
         "@yappr/sdk": "workspace:*",
         "cli-highlight": "^2.1.11",
+        "effect": "^3.21.4",
         "ink": "^7.0.3",
         "ink-spinner": "^5.0.0",
         "ink-text-input": "^6.0.0",
@@ -967,6 +968,8 @@
 
     "ee-first": ["ee-first@1.1.1", "", {}, "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="],
 
+    "effect": ["effect@3.21.4", "", { "dependencies": { "@standard-schema/spec": "^1.0.0", "fast-check": "^3.23.1" } }, "sha512-B89v/xSgPbl1J2Ai2u18jxq3odpFauU1rC6/eSs4FeNHi72kwKdJp12VGigvRV2lK+kRnx+OOz41XV8guZd4gQ=="],
+
     "electrobun": ["electrobun@1.18.1", "", { "dependencies": { "@babylonjs/core": "^7.45.0", "@types/bun": "^1.3.8", "png-to-ico": "^2.1.8", "proxy-agent": "^6.5.0", "rcedit": "^4.0.1", "three": "^0.165.0" }, "bin": { "electrobun": "bin/electrobun.cjs" } }, "sha512-tgZ+WKGskn/1/Y5i1mpVCCkgRa1O31Tz7MIArBTK44GfPzT43uOq9c/HvxdQGrLeZV8ZvjK1lQrwqSXCgh6tvA=="],
 
     "electron-to-chromium": ["electron-to-chromium@1.5.357", "", {}, "sha512-NHlTIQDK8fmVwHwuIzmXYEJ1Ewq3D9wDNc0cWXxDGysP6Pb21giwGNkxiTifyKy/4SoPuN5l6GLP1W9Sv7zB2g=="],
@@ -1048,6 +1051,8 @@
     "express-rate-limit": ["express-rate-limit@8.5.2", "", { "dependencies": { "ip-address": "^10.2.0" }, "peerDependencies": { "express": ">= 4.11" } }, "sha512-5Kb34ipNX694DH48vN9irak1Qx30nb0PLYHXfJgw4YEjiC3ZEmZJhwOp+VfiCYwFzvFTdB9QkArYS5kXa2cx2A=="],
 
     "extend": ["extend@3.0.2", "", {}, "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="],
+
+    "fast-check": ["fast-check@3.23.2", "", { "dependencies": { "pure-rand": "^6.1.0" } }, "sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A=="],
 
     "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
 
@@ -1592,6 +1597,8 @@
     "proxy-from-env": ["proxy-from-env@1.1.0", "", {}, "sha512-D+zkORCbA9f1tdWRK0RaCR3GPv50cMxcrz4X8k5LTSUD1Dkw47mKJEZQNunItRTkWwgtaUSo1RVFRIG9ZXiFYg=="],
 
     "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
+
+    "pure-rand": ["pure-rand@6.1.0", "", {}, "sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA=="],
 
     "qs": ["qs@6.15.2", "", { "dependencies": { "side-channel": "^1.1.0" } }, "sha512-Rzq0KEyX/w/tEybncDgdkZrJgVUsUMk3xjh3t5bv3S1HTAtg+uOYt72+ZfwiQwKdysThkTBdL/rTi6HDmX9Ddw=="],
 

--- a/bun.lock
+++ b/bun.lock
@@ -133,7 +133,9 @@
       "name": "@yappr/lib",
       "version": "0.0.1",
       "dependencies": {
+        "effect": "^3.21.4",
         "marked": "^18.0.3",
+        "neverthrow": "^8.2.0",
       },
     },
     "packages/sdk": {

--- a/docs/adr/0001-effect-migration.md
+++ b/docs/adr/0001-effect-migration.md
@@ -1,0 +1,67 @@
+# 1. Migrate the TypeScript stack to Effect
+
+Date: 2026-06-24
+
+## Status
+
+Accepted
+
+## Context
+
+The TypeScript side of yappr (`packages/lib`, `packages/sdk`, `packages/db`,
+`apps/cli`, `apps/desktop`) models recoverable failure with `neverthrow`
+(`Result` / `ResultAsync`), with `zod` at IO boundaries and `ts-pattern` for
+branching. This works, but the service core — MCP tool lifecycle, voice/TTS/STT
+clients, the inference orchestration in `chat()` — carries manual resource
+cleanup (`try/finally`), manual `AbortController` threading for cancellation,
+and hand-rolled dependency injection (the `ChatRuntime` object passed for
+testability).
+
+A spike (`spike/effect-chat-session`, `chatEffect()`) re-expressed `chat()` in
+Effect and demonstrated, with tests, three concrete wins for that layer:
+
+- `Scope` / `acquireRelease` guarantees MCP `close()` on success, failure, and
+  interruption (no `try/finally`).
+- `Layer` / `Context.Tag` turns the ad-hoc `ChatRuntime` injection into typed DI.
+- Structured interruption replaces `AbortController` threading.
+
+The cost is also real: ~50% more lines for simple flows, a neverthrow↔Effect
+bridge tax during partial adoption, a larger bundle in the desktop webview, and
+a genuine learning curve ("Effect owns control flow").
+
+We are choosing to adopt Effect across the whole TS surface so the bridge tax
+is temporary rather than permanent.
+
+## Decision
+
+1. **Error model** — domain failures at `sdk`/`db` boundaries become tagged
+   errors (`Data.TaggedError`); plain `Error` elsewhere where callers only need
+   a message.
+2. **Coexistence** — migrate bottom-up, package by package (`lib` → `sdk` →
+   `db` → `cli` → `desktop`), with temporary neverthrow↔Effect bridges at the
+   seams. Each phase ships green behind its own PR.
+3. **Desktop bundle** — use full Effect (not `Micro`) in the webview; the
+   desktop needs `Layer`/`Scope` (chat + voice runtimes), which `Micro` lacks.
+   Accept the bundle cost; code-split if it bites.
+4. **TanStack Query integration** — run Effects inside `queryFn`/`mutationFn`
+   via a shared `ManagedRuntime`; do not add `effect-query`. Keeps the existing
+   TanStack Query/Store layer.
+5. **Schema** — keep `zod` (drizzle-zod, schema-first convention). Effect Schema
+   is out of scope; this migration is about the error/effect model only.
+
+## Consequences
+
+- A short-lived bridge module (`@yappr/lib/effect`: `fromResultAsync`,
+  `toResultAsync`) lets migrated and unmigrated packages interoperate; it is
+  deleted in the final cleanup phase when `neverthrow` is removed.
+- `python/` is unaffected (separate runtime).
+- Until cleanup, both `neverthrow` and `effect` are dependencies.
+
+## Alternatives considered
+
+- **Keep neverthrow** — lowest churn, but the resource-safety and cancellation
+  guarantees stay manual. Rejected: we want those guarantees in the service core.
+- **Effect in the service core only** — keep the UI on neverthrow permanently.
+  Rejected: leaves a permanent bridge tax at every seam.
+- **`Micro` in the desktop** — smaller bundle, but no `Layer`/`Scope`. Rejected:
+  the desktop needs both.

--- a/packages/lib/package.json
+++ b/packages/lib/package.json
@@ -12,9 +12,12 @@
     "./image-path": "./src/image-path.ts",
     "./narration-text": "./src/narration-text.ts",
     "./result": "./src/result.ts",
-    "./telemetry": "./src/telemetry.ts"
+    "./telemetry": "./src/telemetry.ts",
+    "./effect": "./src/effect.ts"
   },
   "dependencies": {
-    "marked": "^18.0.3"
+    "effect": "^3.21.4",
+    "marked": "^18.0.3",
+    "neverthrow": "^8.2.0"
   }
 }

--- a/packages/lib/src/effect.test.ts
+++ b/packages/lib/src/effect.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from "bun:test";
+import { Effect, Exit } from "effect";
+import { errAsync, okAsync } from "neverthrow";
+
+import { fromResultAsync, toResultAsync } from "./effect.js";
+
+describe("fromResultAsync", () => {
+  it("lifts ok into a succeeding Effect", async () => {
+    const value = await Effect.runPromise(fromResultAsync(okAsync(5)));
+    expect(value).toBe(5);
+  });
+
+  it("lifts err into the Effect error channel", async () => {
+    const err = new Error("nope");
+    const exit = await Effect.runPromiseExit(fromResultAsync(errAsync(err)));
+    expect(Exit.isFailure(exit)).toBe(true);
+  });
+});
+
+describe("toResultAsync", () => {
+  it("maps a succeeding Effect to ok", async () => {
+    const result = await toResultAsync(Effect.succeed(5));
+    expect(result.isOk()).toBe(true);
+    expect(result._unsafeUnwrap()).toBe(5);
+  });
+
+  it("maps a failing Effect to err(Error)", async () => {
+    const result = await toResultAsync(Effect.fail(new Error("boom")));
+    expect(result.isErr()).toBe(true);
+    expect(result._unsafeUnwrapErr().message).toBe("boom");
+  });
+
+  it("collapses a defect to err(Error)", async () => {
+    const result = await toResultAsync(Effect.die(new Error("defect")));
+    expect(result.isErr()).toBe(true);
+  });
+
+  it("round-trips through both bridges", async () => {
+    const result = await toResultAsync(fromResultAsync(okAsync("hi")));
+    expect(result._unsafeUnwrap()).toBe("hi");
+  });
+});

--- a/packages/lib/src/effect.ts
+++ b/packages/lib/src/effect.ts
@@ -1,0 +1,38 @@
+import { Cause, Effect, Exit } from "effect";
+import { errAsync, okAsync, ResultAsync } from "neverthrow";
+
+import { toError } from "./result.js";
+
+/**
+ * Bridges between `neverthrow` and `effect`, used at the seams while the stack
+ * migrates package by package (see docs/adr/0001-effect-migration.md). Deleted
+ * in the final cleanup phase once `neverthrow` is gone.
+ */
+
+/** neverthrow → Effect: lift a `ResultAsync` into the Effect error channel. */
+export const fromResultAsync = <A, E>(
+  ra: ResultAsync<A, E>,
+): Effect.Effect<A, E> =>
+  Effect.promise(() => Promise.resolve(ra)).pipe(
+    Effect.flatMap((res) =>
+      res.match(
+        (a) => Effect.succeed(a),
+        (e) => Effect.fail(e),
+      ),
+    ),
+  );
+
+/**
+ * Effect → neverthrow: run a fully-provided Effect (`R = never`) and collapse
+ * its outcome to a `ResultAsync<A, Error>`. Failures and defects both map to
+ * `Error` so neverthrow consumers keep a uniform error channel mid-migration.
+ */
+export const toResultAsync = <A>(
+  effect: Effect.Effect<A, unknown, never>,
+): ResultAsync<A, Error> =>
+  ResultAsync.fromSafePromise(Effect.runPromiseExit(effect)).andThen((exit) =>
+    Exit.match(exit, {
+      onSuccess: (a) => okAsync(a),
+      onFailure: (cause) => errAsync(toError(Cause.squash(cause))),
+    }),
+  );


### PR DESCRIPTION
Phase 1 of the full `neverthrow` → Effect migration. **Foundation only — no consumers migrated yet.**

## What
- **ADR** `docs/adr/0001-effect-migration.md` — records the five decisions: tagged errors at sdk/db boundaries, bottom-up package-by-package with bridges, full Effect (not Micro) in desktop, Effects-in-`queryFn` for TanStack, keep zod.
- **`@yappr/lib/effect`** — the temporary bridges used at seams while packages migrate:
  - `fromResultAsync` (neverthrow → Effect)
  - `toResultAsync` (Effect → neverthrow, collapsing failures + defects to `Error`)
- `effect` + `neverthrow` declared as direct `@yappr/lib` deps.

## Verification
- `bun run check` green: format · lint (5/5) · typecheck (5/5) · **95 tests** (6 new bridge tests).

## Next phases (own PRs)
2. `sdk` (TTS/STT, voice, health, MCP) → Effect services + Layers
3. `db` → Effect
4. `cli` → Effect + Ink edges
5. `desktop` → Effect + TanStack integration
6. cleanup: remove neverthrow + bridges

The `spike/effect-chat-session` branch seeds the Phase 4 chat/MCP work.