### PR TITLE
feat(cli): bounded multi-step tool-use agent loop (Ollama)

### DIFF
--- a/apps/cli/src/services/yappr/chat/adapters/ollama-transport.ts
+++ b/apps/cli/src/services/yappr/chat/adapters/ollama-transport.ts
@@ -1,3 +1,5 @@
+import { maxIterations } from "@tanstack/ai";
+
 import type { ChatRuntime } from "../runtime.js";
 import type {
   ChatStreamEvent,
@@ -9,6 +11,13 @@ export interface OllamaTransportConfig {
   model: string;
   baseUrl?: string | undefined;
 }
+
+/**
+ * Upper bound on agent-loop iterations (tool round-trips) per turn. Bounds the
+ * multi-step tool loop so a model that keeps calling tools can't run away; the
+ * tool-call trace surfaces each round, so hitting the cap is visible.
+ */
+const MAX_TOOL_ITERATIONS = 8;
 
 /**
  * {@link ChatTransport} adapter wrapping `@tanstack/ai` + `@tanstack/ai-ollama`.
@@ -33,6 +42,11 @@ export function createOllamaChatTransport(
           systemPrompts: [...req.systemPrompts],
         }),
         tools: [...req.tools],
+        // Bounded multi-step agent loop, but only when tools are present —
+        // a tool-less turn stays single-shot.
+        ...(req.tools.length > 0 && {
+          agentLoopStrategy: maxIterations(MAX_TOOL_ITERATIONS),
+        }),
         ...(abortController && { abortController }),
       });
 


### PR DESCRIPTION
Closes #14 (Ollama+CLI scope — see note).

## What
Pass `agentLoopStrategy: maxIterations(8)` to the Ollama chat stream **when tools are present**, so a tool-using prompt runs multiple *bounded* tool round-trips in a single turn rather than one step. Tool-less turns stay single-shot. The existing `tool.call` / `tool.result` trace (name · done/error · `elapsedMs`, in the event-stream view) already surfaces each round, distinct from the answer.

## Scope note (the issue was over-specified)
#14's AC assumed tool support that **only exists on the Ollama+CLI path today**:
- **OpenRouter** drops tools (its custom SSE adapter never parsed tool calls) → split to **#23**.
- **Desktop** chat has no MCP/tools at all; wiring it needs a webview↔bun-side MCP execution bridge → split to **#24** (design-first).

So the net-new here is exactly what the issue called for — the **bounded loop** — on the only surface that has tools. The other two AC paths are now their own prerequisite issues.

## Verification
`bun run check` green: biome · typecheck (5/5) · 95 tests. Runtime multi-step behavior needs a live tool-using model (not AFK-testable), but the loop config is correct + bounded.