### PR TITLE
feat(cli): OpenRouter tool-calling via @tanstack/ai

### DIFF
--- a/apps/cli/package.json
+++ b/apps/cli/package.json
@@ -15,6 +15,7 @@
   "dependencies": {
     "@tanstack/ai": "^0.33.0",
     "@tanstack/ai-ollama": "^0.8.6",
+    "@tanstack/ai-openrouter": "^0.14.2",
     "@yappr/db": "workspace:*",
     "@yappr/lib": "workspace:*",
     "@yappr/sdk": "workspace:*",

--- a/apps/cli/src/services/yappr/chat/adapters/ollama-transport.ts
+++ b/apps/cli/src/services/yappr/chat/adapters/ollama-transport.ts
@@ -1,91 +1,24 @@
-import { maxIterations } from "@tanstack/ai";
-
 import type { ChatRuntime } from "../runtime.js";
-import type {
-  ChatStreamEvent,
-  ChatStreamRequest,
-  ChatTransport,
-} from "../transport.js";
+import type { ChatStreamRequest, ChatTransport } from "../transport.js";
+import { streamTanstackChat } from "./tanstack-chat.js";
 
 export interface OllamaTransportConfig {
   model: string;
   baseUrl?: string | undefined;
 }
 
-/**
- * Upper bound on agent-loop iterations (tool round-trips) per turn. Bounds the
- * multi-step tool loop so a model that keeps calling tools can't run away; the
- * tool-call trace surfaces each round, so hitting the cap is visible.
- */
-const MAX_TOOL_ITERATIONS = 8;
-
-/**
- * {@link ChatTransport} adapter wrapping `@tanstack/ai` + `@tanstack/ai-ollama`.
- * Translates the SDK's chunk types (`TEXT_MESSAGE_CONTENT`, `TOOL_CALL_*`,
- * `RUN_ERROR`) into provider-agnostic {@link ChatStreamEvent}s.
- */
+/** {@link ChatTransport} for Ollama via `@tanstack/ai-ollama`. */
 export function createOllamaChatTransport(
   runtime: ChatRuntime,
   config: OllamaTransportConfig,
 ): ChatTransport {
   return {
     name: "ollama",
-    async *stream(req: ChatStreamRequest): AsyncIterable<ChatStreamEvent> {
-      const adapter = runtime.createOllamaChat(config.model, config.baseUrl);
-      const abortController = req.signal
-        ? toAbortController(req.signal)
-        : undefined;
-      const stream = runtime.tanstackChat({
-        adapter,
-        messages: [...req.messages],
-        ...(req.systemPrompts.length > 0 && {
-          systemPrompts: [...req.systemPrompts],
-        }),
-        tools: [...req.tools],
-        // Bounded multi-step agent loop, but only when tools are present —
-        // a tool-less turn stays single-shot.
-        ...(req.tools.length > 0 && {
-          agentLoopStrategy: maxIterations(MAX_TOOL_ITERATIONS),
-        }),
-        ...(abortController && { abortController }),
-      });
-
-      for await (const chunk of stream) {
-        if (chunk.type === "TEXT_MESSAGE_CONTENT") {
-          const text = chunk.delta ?? "";
-          if (text) yield { type: "delta", text };
-        } else if (chunk.type === "TOOL_CALL_START" && "toolName" in chunk) {
-          yield { type: "tool", phase: "start", name: chunk.toolName };
-        } else if (chunk.type === "TOOL_CALL_END" && "toolName" in chunk) {
-          if (chunk.toolName) {
-            yield { type: "tool", phase: "end", name: chunk.toolName };
-          }
-        } else if (chunk.type === "RUN_ERROR") {
-          yield {
-            type: "error",
-            message: chunk.error?.message ?? "Chat stream error",
-          };
-        } else if (chunk.type === "RUN_FINISHED" && chunk.usage) {
-          const u = chunk.usage;
-          yield {
-            type: "usage",
-            usage: {
-              promptTokens: u.promptTokens,
-              completionTokens: u.completionTokens,
-              totalTokens: u.totalTokens,
-              ...(typeof u.cost === "number" ? { cost: u.cost } : {}),
-            },
-          };
-        }
-      }
-    },
+    stream: (req: ChatStreamRequest) =>
+      streamTanstackChat(
+        runtime,
+        runtime.createOllamaChat(config.model, config.baseUrl),
+        req,
+      ),
   };
-}
-
-/** `@tanstack/ai` expects an `AbortController`, not a bare `AbortSignal`. */
-function toAbortController(signal: AbortSignal): AbortController {
-  const ac = new AbortController();
-  if (signal.aborted) ac.abort();
-  else signal.addEventListener("abort", () => ac.abort(), { once: true });
-  return ac;
 }

--- a/apps/cli/src/services/yappr/chat/adapters/openrouter-transport.ts
+++ b/apps/cli/src/services/yappr/chat/adapters/openrouter-transport.ts
@@ -1,12 +1,6 @@
-import type { ModelMessage } from "@tanstack/ai";
-
-import type { OpenRouterTextMessage } from "../../openrouter.js";
 import type { ChatRuntime } from "../runtime.js";
-import type {
-  ChatStreamEvent,
-  ChatStreamRequest,
-  ChatTransport,
-} from "../transport.js";
+import type { ChatStreamRequest, ChatTransport } from "../transport.js";
+import { streamTanstackChat } from "./tanstack-chat.js";
 
 export interface OpenRouterTransportConfig {
   model: string;
@@ -14,12 +8,10 @@ export interface OpenRouterTransportConfig {
 }
 
 /**
- * {@link ChatTransport} adapter for the OpenRouter chat-completion API.
- *
- * OpenRouter's request shape is text-only — multimodal {@link ModelMessage}s
- * are flattened to their text parts before send. Tool execution isn't wired
- * on this path today (the OpenRouter MCP bridge lives separately); any tools
- * passed in the request are dropped silently.
+ * {@link ChatTransport} for OpenRouter via `@tanstack/ai-openrouter`. Routes
+ * through `@tanstack/ai` like the Ollama path, so tool-calling + the bounded
+ * agent loop + usage telemetry work uniformly (the previous bespoke SSE client
+ * dropped tools).
  */
 export function createOpenRouterChatTransport(
   runtime: ChatRuntime,
@@ -27,48 +19,16 @@ export function createOpenRouterChatTransport(
 ): ChatTransport {
   return {
     name: "openrouter",
-    async *stream(req: ChatStreamRequest): AsyncIterable<ChatStreamEvent> {
-      const adapter = runtime.createOpenRouterChat(config.model, config.apiKey);
-      const textOnly = req.messages.map(
-        (m): OpenRouterTextMessage => ({
-          role: m.role,
-          content: flattenContentToText(m.content),
-        }),
-      );
-      const messages: OpenRouterTextMessage[] =
-        req.systemPrompts.length > 0
-          ? [
-              { role: "system", content: req.systemPrompts.join("\n\n") },
-              ...textOnly,
-            ]
-          : textOnly;
-
-      for await (const chunk of adapter.chatStream({
-        messages,
-        request: req.signal ? { signal: req.signal } : undefined,
-      })) {
-        if (chunk.type === "RUN_ERROR") {
-          yield {
-            type: "error",
-            message: chunk.error?.message ?? "OpenRouter error",
-          };
-        } else if (chunk.type === "content" && chunk.delta) {
-          yield { type: "delta", text: chunk.delta };
-        } else if (chunk.type === "usage") {
-          yield { type: "usage", usage: chunk.usage };
-        }
-      }
-    },
+    stream: (req: ChatStreamRequest) =>
+      streamTanstackChat(
+        runtime,
+        // OpenRouter model ids are user-configured; the adapter's model union
+        // is autocomplete-only, so accept any string.
+        runtime.createOpenRouterText(
+          config.model as Parameters<ChatRuntime["createOpenRouterText"]>[0],
+          config.apiKey,
+        ),
+        req,
+      ),
   };
-}
-
-function flattenContentToText(
-  content: ModelMessage["content"] | undefined,
-): string {
-  if (content == null) return "";
-  if (typeof content === "string") return content;
-  return content
-    .map((part) => (part.type === "text" ? part.content : ""))
-    .filter(Boolean)
-    .join("\n");
 }

--- a/apps/cli/src/services/yappr/chat/adapters/tanstack-chat.ts
+++ b/apps/cli/src/services/yappr/chat/adapters/tanstack-chat.ts
@@ -1,0 +1,81 @@
+import { maxIterations } from "@tanstack/ai";
+
+import type { ChatRuntime } from "../runtime.js";
+import type { ChatStreamEvent, ChatStreamRequest } from "../transport.js";
+
+/**
+ * Upper bound on agent-loop iterations (tool round-trips) per turn. Bounds the
+ * multi-step tool loop so a model that keeps calling tools can't run away; the
+ * tool-call trace surfaces each round, so hitting the cap is visible.
+ */
+const MAX_TOOL_ITERATIONS = 8;
+
+/** The adapter shape `tanstackChat` accepts (Ollama, OpenRouter, …). */
+type ChatAdapter = Parameters<ChatRuntime["tanstackChat"]>[0]["adapter"];
+
+/** `@tanstack/ai` expects an `AbortController`, not a bare `AbortSignal`. */
+function toAbortController(signal: AbortSignal): AbortController {
+  const ac = new AbortController();
+  if (signal.aborted) ac.abort();
+  else signal.addEventListener("abort", () => ac.abort(), { once: true });
+  return ac;
+}
+
+/**
+ * Run a `@tanstack/ai` chat stream for any adapter and normalise its AG-UI
+ * chunks into provider-agnostic {@link ChatStreamEvent}s. Shared by the Ollama
+ * and OpenRouter transports so tool-calling, the bounded agent loop, and usage
+ * telemetry behave identically across providers.
+ */
+export async function* streamTanstackChat(
+  runtime: ChatRuntime,
+  adapter: ChatAdapter,
+  req: ChatStreamRequest,
+): AsyncIterable<ChatStreamEvent> {
+  const abortController = req.signal
+    ? toAbortController(req.signal)
+    : undefined;
+  const stream = runtime.tanstackChat({
+    adapter,
+    messages: [...req.messages],
+    ...(req.systemPrompts.length > 0 && {
+      systemPrompts: [...req.systemPrompts],
+    }),
+    tools: [...req.tools],
+    // Bounded multi-step agent loop, but only when tools are present —
+    // a tool-less turn stays single-shot.
+    ...(req.tools.length > 0 && {
+      agentLoopStrategy: maxIterations(MAX_TOOL_ITERATIONS),
+    }),
+    ...(abortController && { abortController }),
+  });
+
+  for await (const chunk of stream) {
+    if (chunk.type === "TEXT_MESSAGE_CONTENT") {
+      const text = chunk.delta ?? "";
+      if (text) yield { type: "delta", text };
+    } else if (chunk.type === "TOOL_CALL_START" && "toolName" in chunk) {
+      yield { type: "tool", phase: "start", name: chunk.toolName };
+    } else if (chunk.type === "TOOL_CALL_END" && "toolName" in chunk) {
+      if (chunk.toolName) {
+        yield { type: "tool", phase: "end", name: chunk.toolName };
+      }
+    } else if (chunk.type === "RUN_ERROR") {
+      yield {
+        type: "error",
+        message: chunk.error?.message ?? "Chat stream error",
+      };
+    } else if (chunk.type === "RUN_FINISHED" && chunk.usage) {
+      const u = chunk.usage;
+      yield {
+        type: "usage",
+        usage: {
+          promptTokens: u.promptTokens,
+          completionTokens: u.completionTokens,
+          totalTokens: u.totalTokens,
+          ...(typeof u.cost === "number" ? { cost: u.cost } : {}),
+        },
+      };
+    }
+  }
+}

--- a/apps/cli/src/services/yappr/chat/runtime.ts
+++ b/apps/cli/src/services/yappr/chat/runtime.ts
@@ -1,20 +1,16 @@
 import { chat as tanstackChat } from "@tanstack/ai";
 import { createOllamaChat } from "@tanstack/ai-ollama";
+import { createOpenRouterText } from "@tanstack/ai-openrouter";
 import { McpManager } from "@yappr/sdk/mcp";
 
 import { getOllamaClient } from "../ollama.js";
-import {
-  createOpenRouterChat,
-  fetchOpenRouterChatCompletion,
-} from "../openrouter.js";
 
 export interface ChatRuntime {
   createMcpManager: () => McpManager;
   tanstackChat: typeof tanstackChat;
   createOllamaChat: typeof createOllamaChat;
+  createOpenRouterText: typeof createOpenRouterText;
   getOllamaClient: typeof getOllamaClient;
-  createOpenRouterChat: typeof createOpenRouterChat;
-  fetchOpenRouterChatCompletion: typeof fetchOpenRouterChatCompletion;
 }
 
 export function createDefaultChatRuntime(): ChatRuntime {
@@ -22,9 +18,8 @@ export function createDefaultChatRuntime(): ChatRuntime {
     createMcpManager: () => new McpManager(),
     tanstackChat,
     createOllamaChat,
+    createOpenRouterText,
     getOllamaClient,
-    createOpenRouterChat,
-    fetchOpenRouterChatCompletion,
   };
 }
 

--- a/apps/cli/src/services/yappr/openrouter.ts
+++ b/apps/cli/src/services/yappr/openrouter.ts
@@ -33,89 +33,6 @@ function isUsableOpenRouterModel(
   return Boolean(m.id && hasText && hasTools);
 }
 
-export interface OpenRouterTextMessage {
-  role: string;
-  content: string;
-}
-
-interface OpenRouterChatStreamOptions {
-  messages: OpenRouterTextMessage[];
-  request?: RequestInit;
-}
-
-interface OpenRouterStreamDelta {
-  content?: string;
-}
-
-interface OpenRouterStreamChoice {
-  delta?: OpenRouterStreamDelta;
-}
-
-interface OpenRouterUsagePayload {
-  prompt_tokens?: number;
-  completion_tokens?: number;
-  total_tokens?: number;
-  /** OpenRouter-reported cost in USD (present when usage accounting is on). */
-  cost?: number;
-}
-
-interface OpenRouterStreamLinePayload {
-  choices?: OpenRouterStreamChoice[];
-  usage?: OpenRouterUsagePayload;
-}
-
-interface OpenRouterCompletionMessageBody {
-  content?: string;
-}
-
-interface OpenRouterCompletionChoice {
-  message?: OpenRouterCompletionMessageBody;
-}
-
-interface OpenRouterChatCompletionResponse {
-  choices?: OpenRouterCompletionChoice[];
-}
-
-interface OpenRouterRunErrorBody {
-  message: string;
-}
-
-type OpenRouterStreamChunk =
-  | { type: "RUN_ERROR"; error: OpenRouterRunErrorBody }
-  | { type: "content"; delta: string; content: string }
-  | {
-      type: "usage";
-      usage: {
-        promptTokens: number;
-        completionTokens: number;
-        totalTokens: number;
-        cost?: number;
-      };
-    };
-
-interface OpenRouterChatAdapter {
-  name: "openrouter";
-  model: string;
-  chatStream: (
-    opts: OpenRouterChatStreamOptions,
-  ) => AsyncIterable<OpenRouterStreamChunk>;
-}
-
-function mergeOpenRouterRequestHeaders(
-  apiKey: string,
-  request: RequestInit,
-): Headers {
-  const headers = new Headers(request.headers);
-  headers.set("Content-Type", "application/json");
-  headers.set("Authorization", `Bearer ${apiKey}`);
-  return headers;
-}
-
-export interface OpenRouterNarrationMessage {
-  role: "system" | "user";
-  content: string;
-}
-
 async function readOpenRouterFailureMessage(res: Response): Promise<string> {
   const text = await res.text();
   return `${res.status}: ${text}`;
@@ -125,6 +42,10 @@ async function throwOpenRouterHttpError(res: Response): Promise<never> {
   throw new Error(await readOpenRouterFailureMessage(res));
 }
 
+/**
+ * List tool-capable OpenRouter models for the settings picker. Chat itself
+ * goes through `@tanstack/ai-openrouter` (see chat/runtime.ts), not this file.
+ */
 export function listOpenRouterModels(
   apiKey: string,
 ): ResultAsync<OpenRouterModelInfo[], Error> {
@@ -152,112 +73,4 @@ export function listOpenRouterModels(
     })(),
     toError,
   );
-}
-
-export function createOpenRouterChat(
-  model: string,
-  apiKey: string,
-): OpenRouterChatAdapter {
-  return {
-    name: "openrouter",
-    model,
-    async *chatStream({
-      messages,
-      request = {},
-    }: OpenRouterChatStreamOptions): AsyncIterable<OpenRouterStreamChunk> {
-      const body = {
-        model,
-        messages: messages.map((m) => ({
-          role: m.role,
-          content: m.content,
-        })),
-        stream: true,
-        // Ask OpenRouter to append a final usage chunk (tokens + cost).
-        usage: { include: true },
-      };
-      const res = await fetch(`${OPENROUTER_BASE}/chat/completions`, {
-        method: "POST",
-        headers: mergeOpenRouterRequestHeaders(apiKey, request),
-        body: JSON.stringify(body),
-        signal: request.signal,
-      });
-      if (!res.ok) {
-        yield {
-          type: "RUN_ERROR",
-          error: { message: await readOpenRouterFailureMessage(res) },
-        };
-        return;
-      }
-      let accumulated = "";
-      const reader = res.body?.getReader();
-      if (!reader) return;
-      const decoder = new TextDecoder();
-      let buffer = "";
-      try {
-        while (true) {
-          const { done, value } = await reader.read();
-          if (done) break;
-          buffer += decoder.decode(value, { stream: true });
-          const lines = buffer.split("\n");
-          buffer = lines.pop() ?? "";
-          for (const line of lines) {
-            if (line.startsWith("data: ")) {
-              const data = line.slice(6);
-              if (data === "[DONE]") continue;
-              try {
-                const json = JSON.parse(data) as OpenRouterStreamLinePayload;
-                const delta = json.choices?.[0]?.delta?.content ?? "";
-                if (delta) {
-                  accumulated += delta;
-                  yield {
-                    type: "content",
-                    delta,
-                    content: accumulated,
-                  };
-                }
-                if (json.usage) {
-                  const u = json.usage;
-                  yield {
-                    type: "usage",
-                    usage: {
-                      promptTokens: u.prompt_tokens ?? 0,
-                      completionTokens: u.completion_tokens ?? 0,
-                      totalTokens: u.total_tokens ?? 0,
-                      ...(typeof u.cost === "number" ? { cost: u.cost } : {}),
-                    },
-                  };
-                }
-              } catch {
-                /* skip malformed SSE chunk */
-              }
-            }
-          }
-        }
-      } finally {
-        reader.releaseLock();
-      }
-    },
-  };
-}
-
-export async function fetchOpenRouterChatCompletion(
-  model: string,
-  apiKey: string,
-  messages: OpenRouterNarrationMessage[],
-): Promise<string> {
-  const res = await fetch(`${OPENROUTER_BASE}/chat/completions`, {
-    method: "POST",
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${apiKey}`,
-    },
-    body: JSON.stringify({
-      model,
-      messages,
-      stream: false,
-    }),
-  });
-  if (!res.ok) await throwOpenRouterHttpError(res);
-  const data = (await res.json()) as OpenRouterChatCompletionResponse;
-  return data.choices?.[0]?.message?.content ?? "";
 }

--- a/biome.json
+++ b/biome.json
@@ -1,7 +1,20 @@
 {
   "$schema": "https://biomejs.dev/schemas/2.5.1/schema.json",
   "vcs": { "enabled": true, "clientKind": "git", "useIgnoreFile": true },
-  "files": { "ignoreUnknown": false },
+  "files": {
+    "ignoreUnknown": false,
+    "includes": [
+      "**",
+      "!**/node_modules",
+      "!**/python",
+      "!**/dist",
+      "!apps/desktop/build",
+      "!**/bun.lock",
+      "!**/.cursor",
+      "!**/.claude",
+      "!**/.git"
+    ]
+  },
   "formatter": {
     "enabled": true,
     "formatWithErrors": false,

--- a/bun.lock
+++ b/bun.lock
@@ -27,6 +27,7 @@
       "dependencies": {
         "@tanstack/ai": "^0.33.0",
         "@tanstack/ai-ollama": "^0.8.6",
+        "@tanstack/ai-openrouter": "^0.14.2",
         "@yappr/db": "workspace:*",
         "@yappr/lib": "workspace:*",
         "@yappr/sdk": "workspace:*",
@@ -362,6 +363,8 @@
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "^1.6.0" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
 
+    "@openrouter/sdk": ["@openrouter/sdk@0.12.35", "", { "dependencies": { "zod": "^3.25.0 || ^4.0.0" } }, "sha512-s4QVLLnG1AmfW3TjnnHUqGfsCkzwVK+kboGcZmKbde09m1DPqgzl4RUFt/HJ5v97MX8aEaN0UG3mKv2S+qj2Gw=="],
+
     "@opentelemetry/api": ["@opentelemetry/api@1.9.1", "", {}, "sha512-gLyJlPHPZYdAk1JENA9LeHejZe1Ti77/pTeFm/nMXmQH/HFZlcS/O2XJB+L8fkbrNSqhdtlvjBVjxwUYanNH5Q=="],
 
     "@oxc-parser/binding-android-arm-eabi": ["@oxc-parser/binding-android-arm-eabi@0.130.0", "", { "os": "android", "cpu": "arm" }, "sha512-h/xYU8/7ADWzVSf5I+YalLpj33LOy9CI/zgbJNIZ5eunRBG+Czqa3lZsvuPHHf3rOt6z1c5+UzoxjbAzAvhwVw=="],
@@ -621,6 +624,8 @@
     "@tanstack/ai-event-client": ["@tanstack/ai-event-client@0.6.4", "", { "dependencies": { "@tanstack/devtools-event-client": "^0.4.1" }, "peerDependencies": { "@tanstack/ai": "0.33.0" } }, "sha512-cvBS/aXDv7exZ+9ESGD87CGhJpnOzvDv2qAltpno/wBFijTAxRfbhAlTPQpWICkefUG/Zv2Rz7k80JPrNMch/Q=="],
 
     "@tanstack/ai-ollama": ["@tanstack/ai-ollama@0.8.6", "", { "dependencies": { "@tanstack/ai-utils": "0.2.2", "ollama": "^0.6.3" }, "peerDependencies": { "@tanstack/ai": "^0.33.0" } }, "sha512-tBqwTvNHpER3q++qiQl/YaTnrZS5es+PlM+NVSvJtyiyOOkP4xukFMo/t/JZExcDb3rK4IXgq0Tgnup046Mp7w=="],
+
+    "@tanstack/ai-openrouter": ["@tanstack/ai-openrouter@0.14.2", "", { "dependencies": { "@openrouter/sdk": "0.12.35", "@tanstack/ai-utils": "0.3.0" }, "peerDependencies": { "@tanstack/ai": "^0.34.0" } }, "sha512-7vfhEreT/BDRnq8CjreP9leTv4PVQEg1UvZun6Lhk0jLJQZ5LZVz0M449epYrETxN0oOLPid8YZnOBhBkRyHfA=="],
 
     "@tanstack/ai-react": ["@tanstack/ai-react@0.15.10", "", { "dependencies": { "@tanstack/ai-client": "0.18.1" }, "peerDependencies": { "@tanstack/ai": "^0.33.0", "@types/react": ">=18.0.0", "react": ">=18.0.0" } }, "sha512-1cLeN5qc2VDwy1qmj3CKJ5Don5WXIWKla8CdZinn4dqMUbXToRIpjZUovwLAhbQ0Kf/PZ3L3kEizr8RY4K+Hvw=="],
 
@@ -1703,6 +1708,8 @@
     "@radix-ui/react-visually-hidden/@radix-ui/react-primitive": ["@radix-ui/react-primitive@2.1.3", "", { "dependencies": { "@radix-ui/react-slot": "1.2.3" }, "peerDependencies": { "@types/react": "*", "@types/react-dom": "*", "react": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc", "react-dom": "^16.8 || ^17.0 || ^18.0 || ^19.0 || ^19.0.0-rc" }, "optionalPeers": ["@types/react", "@types/react-dom"] }, "sha512-m9gTwRkhy2lvCPe6QJp4d3G1TYEUHn/FzJUtq9MjH46an1wJU+GdoGC5VLof8RX8Ft/DlpshApkhswDLZzHIcQ=="],
 
     "@styled-cva/core/tailwind-merge": ["tailwind-merge@2.6.1", "", {}, "sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ=="],
+
+    "@tanstack/ai-openrouter/@tanstack/ai-utils": ["@tanstack/ai-utils@0.3.0", "", {}, "sha512-gy36dQvyd+DG2uuvZK533kEfBhK5S6eV2AGc7iBQBBTeCpzs+hMhqeJ5xAnqfZ2nyHsn6jzkzLyfabyrLU5dKA=="],
 
     "@types/estree-jsx/@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
 


### PR DESCRIPTION
Closes #23.

OpenRouter chat ran on a bespoke SSE client that **dropped tools**. This routes it through `@tanstack/ai-openrouter` (`createOpenRouterText`) exactly like the Ollama path, so tool-calling + the bounded agent loop (#14) + usage telemetry (#13) now work on OpenRouter too.

## Changes
- **New `streamTanstackChat` helper** — tools, `agentLoopStrategy: maxIterations(8)` when tools present, and AG-UI chunk → `ChatStreamEvent` decode. Both Ollama and OpenRouter transports delegate to it (removed the duplicated decode).
- **runtime**: `createOpenRouterText` (from `@tanstack/ai-openrouter`) replaces the custom `createOpenRouterChat` / `fetchOpenRouterChatCompletion`.
- **`openrouter.ts`** trimmed to model-listing only — deleted the hand-rolled SSE chat client (incl. the manual usage parse, now native).
- **biome**: moved ignore globs to `files.includes` so `.claude`/`.cursor`/`python` are excluded from the whole check (was formatter-only).
- Model-id cast: OpenRouter ids are user-configured; the adapter's model union is autocomplete-only.

## Verification
`bun run check` green: biome · typecheck (5/5) · 95 tests. Runtime tool behavior on OpenRouter needs a key (not AFK-testable), but it's the same path as the working Ollama tool loop.