### PR TITLE
feat(desktop): MCP tools in desktop chat (#24)

### DIFF
--- a/apps/desktop/src/bun/index.ts
+++ b/apps/desktop/src/bun/index.ts
@@ -1,7 +1,6 @@
 import os from "node:os";
 import path from "node:path";
 import { createDb, importSettingsJsonIfFresh } from "@yappr/db";
-import type { DbRpcSchema } from "@yappr/db/rpc";
 import {
   BrowserWindow,
   defineElectrobunRPC,
@@ -9,7 +8,9 @@ import {
   Utils,
 } from "electrobun/bun";
 
+import type { AppRpcSchema } from "../rpc-schema";
 import { makeDbRpcHandlers } from "./db-rpc";
+import { makeMcpRpcHandlers } from "./mcp-rpc";
 
 const DEV_SERVER_PORT = 5173;
 const DEV_SERVER_URL = `http://localhost:${DEV_SERVER_PORT}`;
@@ -45,8 +46,9 @@ if (importResult.kind === "imported") {
   console.log(`Migrated ${importResult.count} legacy settings into DB.`);
 }
 
-const rpc = defineElectrobunRPC<DbRpcSchema, "bun">("bun", {
-  handlers: { requests: makeDbRpcHandlers(db) },
+const mcp = makeMcpRpcHandlers();
+const rpc = defineElectrobunRPC<AppRpcSchema, "bun">("bun", {
+  handlers: { requests: { ...makeDbRpcHandlers(db), ...mcp.requests } },
 });
 
 const mainWindow = new BrowserWindow({
@@ -70,6 +72,7 @@ const mainWindow = new BrowserWindow({
 // launcher quits cleanly instead of leaving the main process orphaned.
 mainWindow.on("close", () => {
   db.close();
+  void mcp.close();
   Utils.quit();
 });
 

--- a/apps/desktop/src/bun/mcp-rpc.ts
+++ b/apps/desktop/src/bun/mcp-rpc.ts
@@ -1,0 +1,55 @@
+import { McpManager } from "@yappr/sdk/mcp";
+import {
+  McpCallToolInput,
+  type McpCallToolResult,
+  type McpToolMeta,
+} from "@yappr/sdk/mcp-rpc";
+import { Effect } from "effect";
+
+/**
+ * Bun-side handlers for the desktop MCP tool-execution bridge (ADR 0002).
+ *
+ * MCP servers are processes, so the `McpManager` lives here (alongside the
+ * SQLite handle), not in the webview. It connects **lazily** on the first
+ * `mcp:listTools` — a session that never uses tools pays nothing — and the same
+ * connection is reused for the app's lifetime. Config comes from the sdk's
+ * `resolveMcpConfigPath()` cascade, so desktop + CLI see the same servers.
+ */
+export interface McpRpc {
+  requests: {
+    "mcp:listTools": () => Promise<McpToolMeta[]>;
+    "mcp:callTool": (params: unknown) => Promise<McpCallToolResult>;
+  };
+  close: () => Promise<void>;
+}
+
+export function makeMcpRpcHandlers(): McpRpc {
+  let manager: McpManager | null = null;
+  let ready: Promise<McpManager> | null = null;
+
+  const ensure = (): Promise<McpManager> => {
+    if (!ready) {
+      const mgr = new McpManager();
+      manager = mgr;
+      ready = Effect.runPromise(mgr.loadConfigAndGetStatuses()).then(() => mgr);
+    }
+    return ready;
+  };
+
+  return {
+    requests: {
+      "mcp:listTools": async () => (await ensure()).getToolMetadata(),
+      "mcp:callTool": async (params) => {
+        const { name, args } = McpCallToolInput.parse(params);
+        const mgr = await ensure();
+        const result = await Effect.runPromise(mgr.callTool(name, args));
+        return { content: result.content };
+      },
+    },
+    close: async () => {
+      if (manager) await manager.close();
+      manager = null;
+      ready = null;
+    },
+  };
+}

--- a/apps/desktop/src/mainview/app/screens/chat/components/panel.tsx
+++ b/apps/desktop/src/mainview/app/screens/chat/components/panel.tsx
@@ -7,6 +7,7 @@ import {
   RefreshCcw,
   Square,
   Volume2,
+  Wrench,
 } from "lucide-react";
 import { memo, useEffect, useRef, useState } from "react";
 
@@ -29,7 +30,12 @@ import {
   MessageContent,
 } from "~/ui/message";
 import { Composer } from "../../../components/composer";
-import { chatMessageText, useChatContext, useChatSession } from "../store";
+import {
+  chatMessageText,
+  type ToolTraceEntry,
+  useChatContext,
+  useChatSession,
+} from "../store";
 import { KaraokeCaptions } from "./karaoke-captions";
 
 export function ChatPanel() {
@@ -107,6 +113,9 @@ export function ChatPanel() {
               );
             })
           )}
+          {session.toolTrace.length > 0 ? (
+            <ToolTrace entries={session.toolTrace} />
+          ) : null}
           {session.showLoading ? <LoadingMessage /> : null}
           {session.error ? (
             <ErrorMessage message={session.error.message} />
@@ -362,6 +371,37 @@ const LoadingMessage = memo(function LoadingMessage() {
     <Message className="mx-auto flex w-full max-w-3xl flex-col gap-1">
       <div className="text-muted-foreground py-2">
         <DotsLoader />
+      </div>
+    </Message>
+  );
+});
+
+const ToolTrace = memo(function ToolTrace({
+  entries,
+}: {
+  entries: ToolTraceEntry[];
+}) {
+  return (
+    <Message className="mx-auto flex w-full max-w-3xl flex-col gap-1">
+      <div className="flex flex-col gap-1 rounded-lg border border-border/60 bg-muted/30 px-3 py-2 font-mono text-[11px] text-foil-mute">
+        {entries.map((t) => (
+          <div key={t.id} className="flex items-center gap-2">
+            <Wrench
+              className={cn("size-3 shrink-0", {
+                "animate-pulse": t.status === "running",
+              })}
+              aria-hidden="true"
+            />
+            <span className="text-foreground/80">{t.name}</span>
+            <span>
+              {t.status === "running"
+                ? "running…"
+                : t.elapsedMs
+                  ? `${(t.elapsedMs / 1000).toFixed(1)}s`
+                  : "done"}
+            </span>
+          </div>
+        ))}
       </div>
     </Message>
   );

--- a/apps/desktop/src/mainview/app/screens/chat/store.tsx
+++ b/apps/desktop/src/mainview/app/screens/chat/store.tsx
@@ -29,8 +29,17 @@ import {
   ollamaModelsOptions,
   preferencesOptions,
 } from "~/lib/queries";
+import { buildMcpTools, mcpToolsOptions } from "~/services/mcp/tools";
 import { DEFAULT_CHAT_MODEL, pickModel } from "~/services/ollama";
 import { createOllamaConnection } from "~/services/ollama/transport";
+
+/** A tool round-trip surfaced in the chat trace, distinct from the answer. */
+export interface ToolTraceEntry {
+  id: string;
+  name: string;
+  status: "running" | "done";
+  elapsedMs?: number;
+}
 
 /**
  * Chat client/UI state — the only state shared across the chat subtree. The
@@ -173,6 +182,8 @@ export interface ChatSession {
   modelsLoaded: boolean;
   /** Stats for the most recent completed turn; null until the first reply. */
   telemetry: TurnTelemetry | null;
+  /** Tool round-trips for the current turn, in call order. */
+  toolTrace: ToolTraceEntry[];
   submit: (text: string, files: Attachment[]) => Promise<void>;
   regenerateMessage: (messageId: string) => Promise<void>;
   stop: () => void;
@@ -212,6 +223,16 @@ export function useChatSession(): ChatSession {
     );
   }, [persisted]);
 
+  // MCP tools (ADR 0002): metadata fetched over RPC, execution bridged to bun.
+  // Read live via a ref so tools arriving after first render still apply
+  // without recreating the frozen useChat connection.
+  const { data: toolMetas } = useQuery(mcpToolsOptions);
+  const tools = useMemo(() => buildMcpTools(toolMetas ?? []), [toolMetas]);
+  const toolsRef = useRef(tools);
+  useEffect(() => {
+    toolsRef.current = tools;
+  }, [tools]);
+
   // useChat freezes the connection at first render; read the live model via a
   // ref so switching models takes effect without recreating the chat instance.
   const modelRef = useRef(model);
@@ -219,7 +240,35 @@ export function useChatSession(): ChatSession {
     modelRef.current = model;
   }, [model]);
   const connection = useMemo(
-    () => createOllamaConnection(() => modelRef.current),
+    () =>
+      createOllamaConnection(
+        () => modelRef.current,
+        () => toolsRef.current,
+      ),
+    [],
+  );
+
+  // Tool-call trace for the current turn + start-times so TOOL_CALL_END can
+  // compute elapsed. Persisted to agent-events for cross-surface replay.
+  const [toolTrace, setToolTrace] = useState<ToolTraceEntry[]>([]);
+  const runIdRef = useRef<string | null>(null);
+  const toolStartedAtRef = useRef(new Map<string, number>());
+  const persistToolEvent = useCallback(
+    (type: "tool.call" | "tool.result", payload: Record<string, unknown>) => {
+      const convId = liveConvIdRef.current;
+      const runId = runIdRef.current;
+      if (!convId || !runId) return;
+      void dbRpc
+        .request("agentEvents:append", {
+          id: crypto.randomUUID(),
+          conversationId: convId,
+          runId,
+          type,
+          eventJson: JSON.stringify({ type, ...payload }),
+          createdAt: Date.now(),
+        })
+        .catch(() => {});
+    },
     [],
   );
 
@@ -235,6 +284,28 @@ export function useChatSession(): ChatSession {
             totalTokens: u.totalTokens,
             ...(typeof u.cost === "number" ? { cost: u.cost } : {}),
           };
+        } else if (chunk.type === "TOOL_CALL_START" && "toolName" in chunk) {
+          const name = String(chunk.toolName);
+          const id = crypto.randomUUID();
+          toolStartedAtRef.current.set(name, Date.now());
+          setToolTrace((prev) => [...prev, { id, name, status: "running" }]);
+          persistToolEvent("tool.call", { name });
+        } else if (chunk.type === "TOOL_CALL_END" && "toolName" in chunk) {
+          const name = String(chunk.toolName);
+          const startedAt = toolStartedAtRef.current.get(name);
+          const elapsedMs = startedAt ? Date.now() - startedAt : undefined;
+          toolStartedAtRef.current.delete(name);
+          setToolTrace((prev) =>
+            prev.map((t) =>
+              t.name === name && t.status === "running"
+                ? { ...t, status: "done", ...(elapsedMs && { elapsedMs }) }
+                : t,
+            ),
+          );
+          persistToolEvent("tool.result", {
+            name,
+            ...(elapsedMs && { elapsedMs }),
+          });
         }
       },
       onFinish: async (message) => {
@@ -314,7 +385,10 @@ export function useChatSession(): ChatSession {
       });
       sentAtRef.current = Date.now();
       usageRef.current = null;
+      runIdRef.current = crypto.randomUUID();
+      toolStartedAtRef.current.clear();
       setTelemetry(null);
+      setToolTrace([]);
       await (files.length > 0
         ? sendMessage({ content: parts })
         : sendMessage(text.trim()));
@@ -330,7 +404,10 @@ export function useChatSession(): ChatSession {
         : null;
       sentAtRef.current = Date.now();
       usageRef.current = null;
+      runIdRef.current = crypto.randomUUID();
+      toolStartedAtRef.current.clear();
       setTelemetry(null);
+      setToolTrace([]);
       try {
         await reload();
       } catch {
@@ -349,6 +426,7 @@ export function useChatSession(): ChatSession {
     modelReady,
     modelsLoaded: Boolean(models),
     telemetry,
+    toolTrace,
     submit,
     regenerateMessage,
     stop,

--- a/apps/desktop/src/mainview/lib/db-rpc.ts
+++ b/apps/desktop/src/mainview/lib/db-rpc.ts
@@ -1,17 +1,18 @@
-import type { DbRpcSchema } from "@yappr/db/rpc";
 import { Electroview } from "electrobun/view";
 
+import type { AppRpcSchema } from "../../rpc-schema";
+
 /**
- * Typed webview-side client for the `~/.yappr/yappr.db` persistence layer.
- * All DB access from React goes through `dbRpc.request("domain:verb", ...)`,
- * which is forwarded over Electrobun's websocket transport to the bun-side
- * handlers in `bun/db-rpc.ts`.
+ * Typed webview-side client for the bun ↔ webview RPC channel: the
+ * `~/.yappr/yappr.db` persistence layer plus the MCP tool bridge (ADR 0002).
+ * All access from React goes through `dbRpc.request("domain:verb", ...)`,
+ * forwarded over Electrobun's websocket transport to the bun-side handlers.
  *
  * Importing this module has a side-effect: it instantiates `Electroview`,
  * which opens the RPC socket. The module-singleton pattern matches Electrobun's
  * own examples — one Electroview per webview lifetime.
  */
-const rpc = Electroview.defineRPC<DbRpcSchema>({
+const rpc = Electroview.defineRPC<AppRpcSchema>({
   handlers: { requests: {} },
 });
 

--- a/apps/desktop/src/mainview/services/mcp/tools.ts
+++ b/apps/desktop/src/mainview/services/mcp/tools.ts
@@ -1,0 +1,40 @@
+import { type SchemaInput, type Tool, toolDefinition } from "@tanstack/ai";
+import { queryOptions } from "@tanstack/react-query";
+import type { McpToolMeta } from "@yappr/sdk/mcp-rpc";
+
+import { dbRpc } from "~/lib/db-rpc";
+
+/**
+ * MCP tools for the desktop agent loop (ADR 0002). Tool *metadata* is fetched
+ * once over RPC; each tool's `.server()` callback round-trips execution to the
+ * bun-side `McpManager` via `mcp:callTool`. The `@tanstack/ai` agent loop runs
+ * in the webview exactly as before — only execution crosses to bun.
+ */
+
+/** Available MCP tools, connecting the bun-side manager lazily on first read. */
+export const mcpToolsOptions = queryOptions({
+  queryKey: ["mcp", "tools"] as const,
+  queryFn: () => dbRpc.request("mcp:listTools"),
+  // Tool roster rarely changes within a run; refetch is cheap but pointless.
+  staleTime: Number.POSITIVE_INFINITY,
+});
+
+/** Build `@tanstack/ai` tools whose execution is bridged to bun over RPC. */
+export function buildMcpTools(
+  metas: McpToolMeta[],
+): Array<Tool<SchemaInput, SchemaInput>> {
+  return metas.map((meta) => {
+    const def = toolDefinition({
+      name: meta.name,
+      description: meta.description ?? "",
+      inputSchema: meta.inputSchema as SchemaInput,
+    });
+    return def.server(async (args: unknown) => {
+      const result = await dbRpc.request("mcp:callTool", {
+        name: meta.name,
+        args: (args ?? {}) as Record<string, unknown>,
+      });
+      return result.content;
+    });
+  });
+}

--- a/apps/desktop/src/mainview/services/ollama/transport.ts
+++ b/apps/desktop/src/mainview/services/ollama/transport.ts
@@ -1,8 +1,13 @@
-import { chat } from "@tanstack/ai";
+import { chat, maxIterations, type SchemaInput, type Tool } from "@tanstack/ai";
 import { createOllamaChat } from "@tanstack/ai-ollama";
 import { stream } from "@tanstack/ai-react";
 
 import { ollamaRoot } from "./index";
+
+/** Upper bound on agent-loop tool round-trips per turn — mirrors the CLI. */
+const MAX_TOOL_ITERATIONS = 8;
+
+type McpTools = Array<Tool<SchemaInput, SchemaInput>>;
 
 /**
  * In-process TanStack AI connection adapter that streams from the local Ollama
@@ -14,12 +19,17 @@ import { ollamaRoot } from "./index";
  * Host comes from {@link ollamaRoot} (same-origin Vite proxy in dev, loopback
  * daemon in the packaged build); the client appends `/api/chat` itself.
  *
- * Model is read through `getModel` on every send so callers can switch models
- * without recreating the connection — `useChat` freezes the adapter reference
- * at first render, so a stable adapter whose behaviour follows the latest model
- * state is what we need.
+ * Model + tools are read through getters on every send so callers can switch
+ * models or have MCP tools arrive after first render — `useChat` freezes the
+ * adapter reference at first render, so a stable adapter whose behaviour follows
+ * the latest state is what we need. When tools are present the bounded
+ * multi-step agent loop is enabled (tools-only, matching the CLI); a tool-less
+ * turn stays single-shot.
  */
-export function createOllamaConnection(getModel: () => string) {
+export function createOllamaConnection(
+  getModel: () => string,
+  getTools: () => McpTools = () => [],
+) {
   return stream((messages, _data, abortSignal) => {
     const adapter = createOllamaChat(getModel(), ollamaRoot());
     const abortController = new AbortController();
@@ -30,6 +40,15 @@ export function createOllamaConnection(getModel: () => string) {
           once: true,
         });
     }
-    return chat({ adapter, messages, abortController });
+    const tools = getTools();
+    return chat({
+      adapter,
+      messages,
+      abortController,
+      ...(tools.length > 0 && {
+        tools,
+        agentLoopStrategy: maxIterations(MAX_TOOL_ITERATIONS),
+      }),
+    });
   });
 }

--- a/apps/desktop/src/rpc-schema.ts
+++ b/apps/desktop/src/rpc-schema.ts
@@ -1,0 +1,19 @@
+import type { DbRpcSchema } from "@yappr/db/rpc";
+import type { McpRpcMethods } from "@yappr/sdk/mcp-rpc";
+
+/**
+ * The desktop's full Electrobun wire contract: the DB persistence methods
+ * (`@yappr/db/rpc`) plus the MCP tool-execution bridge (`@yappr/sdk/mcp-rpc`,
+ * ADR 0002). Types only — imported by both the bun side and the webview, so it
+ * stays free of runtime coupling across the Electrobun boundary.
+ */
+export interface AppRpcSchema {
+  bun: {
+    requests: DbRpcSchema["bun"]["requests"] & McpRpcMethods;
+    messages: Record<string, never>;
+  };
+  webview: {
+    requests: Record<string, never>;
+    messages: Record<string, never>;
+  };
+}

--- a/docs/adr/0002-desktop-mcp-bridge.md
+++ b/docs/adr/0002-desktop-mcp-bridge.md
@@ -1,0 +1,96 @@
+# 2. Desktop MCP tool-execution bridge
+
+Date: 2026-06-24
+
+## Status
+
+Accepted
+
+## Context
+
+The CLI gained a bounded multi-step tool-use agent loop (#25 Ollama, #26
+OpenRouter): `streamTanstackChat` runs `@tanstack/ai` with `getTanStackTools()`
+and `agentLoopStrategy: maxIterations(8)`, executing MCP tools in-process via
+`McpManager` (sdk, Effect-based).
+
+The desktop has **none of this**. Its chat runs entirely in the **webview**:
+`createOllamaConnection` calls `@tanstack/ai`'s `chat({ adapter, messages })`
+directly, streaming from the local Ollama daemon over HTTP (Vite proxy in dev,
+loopback in the packaged build), wired into React through `@tanstack/ai-react`'s
+`useChat`. There are no `tools` and no `agentLoopStrategy`.
+
+MCP servers are **processes** (stdio/HTTP transports, `McpManager` spawns/holds
+clients). They cannot run in the webview. They must run on the Electrobun **bun
+side** — the same process that already owns the SQLite handle and the typed RPC
+channel (`bun/index.ts` → `makeDbRpcHandlers(db)` over `defineElectrobunRPC`).
+
+The question is *where the agent loop runs* and *how a webview-resident loop
+reaches bun-side tools*.
+
+## Decision
+
+**Tools execute over the existing request/response RPC; the agent loop stays in
+the webview.**
+
+1. **Bun side** hosts a single `McpManager`. A new RPC namespace exposes it:
+   - `mcp:listTools` → tool metadata (`name`, `description`, JSON-Schema
+     `inputSchema`) for every connected server.
+   - `mcp:callTool` `{ name, args }` → the MCP `CallToolResult.content`.
+   Both validate input with zod bun-side, same trust model as `db-rpc` (a buggy
+   webview can only reach configured servers' tools). `McpManager` connects
+   **lazily** on the first `mcp:listTools` (config via the sdk's
+   `resolveMcpConfigPath()` — same cascade as the CLI) and is closed alongside
+   `db` on window close.
+
+2. **Webview**, at chat-session start, fetches metadata via `mcp:listTools` and
+   builds `@tanstack/ai` tools whose `.server()` callback round-trips to bun:
+   `toolDefinition({...}).server((args) => dbRpc.request("mcp:callTool", { name, args }))`.
+   These tools + `agentLoopStrategy: maxIterations(8)` are passed into the
+   existing `chat()` call. The loop runs in the webview exactly as today; only
+   tool *execution* crosses to bun.
+
+3. **Tool trace** renders from the `TOOL_CALL_START` / `TOOL_CALL_END` chunks
+   the webview loop already emits — same pattern as the CLI's `onToolCall`,
+   distinct from the answer text — and `tool.call` / `tool.result` events are
+   **persisted to the shared agent-events table** (parity with the CLI) over RPC,
+   so a tools-enabled conversation replays the same on either surface.
+
+The RPC schema lives in a **new `@yappr/sdk` mcp-rpc module**, not `@yappr/db/rpc`
+(which is DB-specific). Scope is **Ollama-only** for v1 — the desktop has no
+OpenRouter transport yet.
+
+## Consequences
+
+- Smallest coherent change: reuses the existing request/response RPC (tool calls
+  are discrete request→response — no streaming-RPC plumbing needed), leaves the
+  webview `useChat` + Ollama streaming path untouched, and mirrors the CLI's
+  `getTanStackTools().server(cb)` shape — only the callback body differs
+  (in-process Effect → RPC call).
+- MCP stays bun-side, its natural home (processes + config + SQLite neighbour).
+- Tool args/results cross the boundary as JSON. MCP payloads are already JSON
+  (`CallToolResult`, JSON-Schema inputs), so this is lossless; per-call
+  round-trip latency is negligible against model + tool latency.
+- Two chat engines persist (webview `chat()` for desktop, bun `streamTanstackChat`
+  for CLI). They share `@tanstack/ai` but aren't unified. Accepted — unifying is
+  a separate, larger concern (see Alternative B).
+- Lazy connect means the first tools-enabled chat pays the MCP connect cost once
+  per app run; a tool-less chat pays nothing.
+
+## Alternatives considered
+
+- **B. Move the whole chat loop to the bun side**, streaming `ChatStreamEvent`s
+  to the webview over RPC (the CLI's `streamTanstackChat`, shared). Unifies CLI +
+  desktop on one engine and keeps MCP entirely bun-side. **Rejected for now:**
+  requires a *streaming* RPC channel (the current one is request/response),
+  discards the `@tanstack/ai-react` `useChat` integration, and is a much larger
+  refactor. The unification upside doesn't justify the plumbing for #24.
+- **C. Static webview tools, no MCP.** Defeats the purpose — MCP servers are
+  dynamic and process-based.
+
+## Resolved decisions
+
+1. **Connect timing** — lazy on first `mcp:listTools`.
+2. **Config source** — the sdk's `resolveMcpConfigPath()` cascade, so desktop +
+   CLI read the same servers.
+3. **Trace persistence** — persist `tool.call` / `tool.result` to the shared
+   agent-events table, matching the CLI.

--- a/packages/sdk/package.json
+++ b/packages/sdk/package.json
@@ -19,6 +19,7 @@
     "./state": "./src/state.ts",
     "./voice": "./src/voice.ts",
     "./mcp": "./src/mcp.ts",
+    "./mcp-rpc": "./src/mcp-rpc.ts",
     "./tts": "./src/tts.ts",
     "./recorder": "./src/recorder.ts",
     "./audio-devices": "./src/audio-devices.ts"

--- a/packages/sdk/src/mcp-rpc.ts
+++ b/packages/sdk/src/mcp-rpc.ts
@@ -1,0 +1,42 @@
+import { z } from "zod";
+
+/**
+ * Wire contract for the desktop's MCP tool-execution bridge (ADR 0002).
+ *
+ * MCP servers run on the Electrobun bun side (processes can't live in the
+ * webview). The webview's `@tanstack/ai` agent loop reaches them over the
+ * existing request/response RPC: `mcp:listTools` for metadata at session start,
+ * `mcp:callTool` for each tool invocation. Both sides import this module — bun
+ * as the handler shape + input validator, webview as the client typings.
+ */
+
+/** A tool the model can call: name + description + raw JSON-Schema input. */
+export const McpToolMetaSchema = z.object({
+  name: z.string(),
+  description: z.string().optional(),
+  /** JSON Schema for the tool's arguments; passed straight to `@tanstack/ai`. */
+  inputSchema: z.unknown(),
+});
+export type McpToolMeta = z.infer<typeof McpToolMetaSchema>;
+
+export const McpCallToolInput = z.object({
+  name: z.string().min(1),
+  args: z.record(z.string(), z.unknown()).default({}),
+});
+export type McpCallToolInput = z.infer<typeof McpCallToolInput>;
+
+/** The `content` blocks of an MCP `CallToolResult` (text/image/resource/…). */
+export interface McpCallToolResult {
+  content: unknown;
+}
+
+/**
+ * The `mcp:*` slice of the desktop's Electrobun `bun.requests`. Composed into
+ * the app-wide schema alongside the DB methods (see desktop `rpc-schema.ts`).
+ * A `type` (not `interface`) so it keeps the implicit string-index signature
+ * Electrobun's `RPCSchema` constraint requires after intersection.
+ */
+export type McpRpcMethods = {
+  "mcp:listTools": { params: undefined; response: McpToolMeta[] };
+  "mcp:callTool": { params: McpCallToolInput; response: McpCallToolResult };
+};

--- a/packages/sdk/src/mcp.ts
+++ b/packages/sdk/src/mcp.ts
@@ -277,6 +277,19 @@ export class McpManager {
     };
   }
 
+  /** Raw tool metadata for the desktop RPC bridge (ADR 0002). */
+  getToolMetadata(): Array<{
+    name: string;
+    description?: string;
+    inputSchema: unknown;
+  }> {
+    return [...this.tools.values()].map(({ tool }) => ({
+      name: tool.name,
+      ...(tool.description ? { description: tool.description } : {}),
+      inputSchema: tool.inputSchema,
+    }));
+  }
+
   getOllamaTools(): OllamaTool[] {
     return [...this.tools.values()].map(({ tool }) => ({
       type: "function",


### PR DESCRIPTION
Closes #24. Implements **ADR 0002** — the desktop chat gains the same bounded multi-step agent loop the CLI has (#25/#26), with MCP tools executing on the Electrobun bun side.

## Architecture (ADR 0002)

The `@tanstack/ai` agent loop **stays in the webview**; only tool *execution* crosses to bun over the existing request/response RPC. No streaming-RPC plumbing, `useChat` + the Ollama path untouched.

- **sdk** — `@yappr/sdk/mcp-rpc` wire schema (`McpToolMeta`, `McpCallToolInput`, `McpRpcMethods`) + `McpManager.getToolMetadata()`.
- **bun side** — `McpManager` hosted here, connected **lazily** on first `mcp:listTools` (config via `resolveMcpConfigPath()`, same as the CLI), closed on window close. `mcp:listTools` + `mcp:callTool` handlers validate input bun-side. A composed `AppRpcSchema` (db + mcp) types both ends.
- **webview** — an `mcp:listTools` query builds `@tanstack/ai` tools whose `.server()` callback RPCs `mcp:callTool`; tools + `maxIterations(8)` feed the Ollama `chat()` (tools-only loop). Tool-call trace renders in the panel and persists `tool.call`/`tool.result` to the shared agent-events table.

## Acceptance criteria (#24)

- [x] Design recorded (ADR 0002)
- [x] MCP tools load + execute from desktop chat (bounded agent loop)
- [x] Tool call + result trace renders, distinct from the answer

## Verification

- biome clean · typecheck 5/5 · 87 tests · renderer bundle builds.
- ⚠️ **Not yet runtime-driven in the live Electrobun window** — needs a `bun run desktop` pass: chat a prompt that triggers a tool, confirm the trace renders and the answer uses the tool result. (Same interactive-GUI gap flagged on the Effect PR.)

Scope: Ollama only (the desktop has no OpenRouter transport yet).
