### PR TITLE
chore: apply onrails tersify codemod

### DIFF
--- a/apps/cli/src/Root.tsx
+++ b/apps/cli/src/Root.tsx
@@ -48,15 +48,11 @@ export function Root() {
     setShowSplash(false);
   }, []);
 
-  if (showSplash) {
-    return (
-      <Box flexDirection="column" height={terminalHeight} width={terminalWidth}>
-        <Splash version={pkg.version} onDismiss={dismissSplash} />
-      </Box>
-    );
-  }
-
-  return (
+  return showSplash ? (
+    <Box flexDirection="column" height={terminalHeight} width={terminalWidth}>
+      <Splash version={pkg.version} onDismiss={dismissSplash} />
+    </Box>
+  ) : (
     <Box flexDirection="column" height={terminalHeight} width={terminalWidth}>
       {effectiveScreen === "menu" && (
         <MainMenuScreen onSelect={(id) => setScreen(id)} />

--- a/apps/cli/src/components/footer.tsx
+++ b/apps/cli/src/components/footer.tsx
@@ -20,9 +20,8 @@ export interface FooterProps {
 
 type ArrowPulse = "up" | "down" | null;
 
-function footerKeyHasArrows(keyText: string) {
-  return keyText.includes(ARROW_UP) || keyText.includes(ARROW_DOWN);
-}
+const footerKeyHasArrows = (keyText: string) =>
+  keyText.includes(ARROW_UP) || keyText.includes(ARROW_DOWN);
 
 function FooterKeyPart(props: { part: string; pulse: ArrowPulse }) {
   const { part, pulse } = props;
@@ -63,26 +62,21 @@ function FooterKeyPart(props: { part: string; pulse: ArrowPulse }) {
 
 function FooterKeyCell(props: { item: FooterItem; pulse: ArrowPulse }) {
   const { item, pulse } = props;
-  if (!footerKeyHasArrows(item.key)) {
-    return (
-      <Text bold color={semantic.accent}>
-        {item.key}
-      </Text>
-    );
-  }
-  return (
-    <>
-      {item.key
-        .split(ARROW_KEY_SPLIT)
-        .filter((p) => p.length > 0)
-        .map((part, j) => (
-          <FooterKeyPart
-            key={`${item.key}-${j}-${part}`}
-            part={part}
-            pulse={pulse}
-          />
-        ))}
-    </>
+  return !footerKeyHasArrows(item.key) ? (
+    <Text bold color={semantic.accent}>
+      {item.key}
+    </Text>
+  ) : (
+    item.key
+      .split(ARROW_KEY_SPLIT)
+      .filter((p) => p.length > 0)
+      .map((part, j) => (
+        <FooterKeyPart
+          key={`${item.key}-${j}-${part}`}
+          part={part}
+          pulse={pulse}
+        />
+      ))
   );
 }
 

--- a/apps/cli/src/components/header.tsx
+++ b/apps/cli/src/components/header.tsx
@@ -7,13 +7,11 @@ export interface HeaderProps {
   subtitle?: string;
 }
 
-export function Header({ title, subtitle }: HeaderProps) {
-  return (
-    <Box marginBottom={1} flexDirection="column">
-      <Text bold color={semantic.accent}>
-        {title}
-      </Text>
-      {subtitle !== undefined && <Text dimColor>{subtitle}</Text>}
-    </Box>
-  );
-}
+export const Header = ({ title, subtitle }: HeaderProps) => (
+  <Box marginBottom={1} flexDirection="column">
+    <Text bold color={semantic.accent}>
+      {title}
+    </Text>
+    {subtitle !== undefined && <Text dimColor>{subtitle}</Text>}
+  </Box>
+);

--- a/apps/cli/src/components/loading.tsx
+++ b/apps/cli/src/components/loading.tsx
@@ -15,15 +15,13 @@ export interface LoadingProps {
   spinner?: LoadingSpinnerName;
 }
 
-export function Loading({
+export const Loading = ({
   message = "Loading...",
   spinner = "dots",
-}: LoadingProps) {
-  return (
-    <Box>
-      <Text color={semantic.accent}>
-        <Spinner type={spinner} /> {message}
-      </Text>
-    </Box>
-  );
-}
+}: LoadingProps) => (
+  <Box>
+    <Text color={semantic.accent}>
+      <Spinner type={spinner} /> {message}
+    </Text>
+  </Box>
+);

--- a/apps/cli/src/constants.ts
+++ b/apps/cli/src/constants.ts
@@ -15,9 +15,8 @@ export const DEFAULT_KEYS = {
   back: ["escape"],
 } as const;
 
-export function wantsBackKey(effectiveKey: string) {
-  return (DEFAULT_KEYS.back as readonly string[]).includes(effectiveKey);
-}
+export const wantsBackKey = (effectiveKey: string) =>
+  (DEFAULT_KEYS.back as readonly string[]).includes(effectiveKey);
 
 export const MENU_ITEMS: Array<{ id: ScreenId; label: string }> = [
   { id: "mcp", label: "MCP servers" },

--- a/apps/cli/src/hooks/useKeyboard.test.ts
+++ b/apps/cli/src/hooks/useKeyboard.test.ts
@@ -2,8 +2,8 @@ import { expect, test } from "bun:test";
 
 import { type ExtendedKey, getEffectiveKey } from "./useKeyboard";
 
-function key(overrides: Partial<ExtendedKey> = {}): ExtendedKey {
-  return {
+const key = (overrides: Partial<ExtendedKey> = {}): ExtendedKey =>
+  ({
     upArrow: false,
     downArrow: false,
     leftArrow: false,
@@ -30,8 +30,7 @@ function key(overrides: Partial<ExtendedKey> = {}): ExtendedKey {
     f11: false,
     f12: false,
     ...overrides,
-  } as ExtendedKey;
-}
+  }) as ExtendedKey;
 
 test("getEffectiveKey maps special keys", () => {
   expect(getEffectiveKey("", key({ escape: true }))).toBe("escape");

--- a/apps/cli/src/hooks/useKeyboard.ts
+++ b/apps/cli/src/hooks/useKeyboard.ts
@@ -44,8 +44,7 @@ export function getEffectiveKey(input: string, key: ExtendedKey): string {
     if (key[fKey]) return fKey;
   }
 
-  if (key.ctrl && input) return `ctrl+${input.toLowerCase()}`;
-  return input;
+  return key.ctrl && input ? `ctrl+${input.toLowerCase()}` : input;
 }
 
 export function useKeyboard({ bindings }: UseKeyboardOptions): void {

--- a/apps/cli/src/lib/chat-persistence.ts
+++ b/apps/cli/src/lib/chat-persistence.ts
@@ -41,11 +41,11 @@ export function createConversationSync(
  * transaction (handled inside the repo). Role mirrors the Ollama/OpenRouter
  * chat contract: `user` | `assistant` | `system`.
  */
-export function appendMessage(
+export const appendMessage = (
   conversationId: string,
   message: ChatMessage,
-): Effect.Effect<void, Error> {
-  return Effect.try({
+): Effect.Effect<void, Error> =>
+  Effect.try({
     try: () => {
       const db = getDb();
       const role = message.role as "user" | "assistant" | "system";
@@ -57,4 +57,3 @@ export function appendMessage(
     },
     catch: toError,
   });
-}

--- a/apps/cli/src/lib/db.ts
+++ b/apps/cli/src/lib/db.ts
@@ -15,13 +15,10 @@ const LEGACY_SETTINGS_FILE = "settings.json";
  */
 const dbCache = new Map<string, YapprDb>();
 
-function getDbPath(): string {
-  return path.join(userHomeDir(), YAPPR_DIR, DB_FILE);
-}
+const getDbPath = (): string => path.join(userHomeDir(), YAPPR_DIR, DB_FILE);
 
-function getLegacySettingsPath(): string {
-  return path.join(userHomeDir(), YAPPR_DIR, LEGACY_SETTINGS_FILE);
-}
+const getLegacySettingsPath = (): string =>
+  path.join(userHomeDir(), YAPPR_DIR, LEGACY_SETTINGS_FILE);
 
 /**
  * Open (or reuse) the shared Yappr SQLite DB at `~/.yappr/yappr.db`. First

--- a/apps/cli/src/lib/preferences-merge.ts
+++ b/apps/cli/src/lib/preferences-merge.ts
@@ -6,9 +6,7 @@ import { parsePreferencesJson } from "./preferences-schema.js";
  * keys and invalid values are silently dropped per-field by
  * {@link parsePreferencesJson}.
  */
-export function mergeStoredPreferences(
+export const mergeStoredPreferences = (
   parsed: unknown,
   defaults: Preferences,
-): Preferences {
-  return { ...defaults, ...parsePreferencesJson(parsed) };
-}
+): Preferences => ({ ...defaults, ...parsePreferencesJson(parsed) });

--- a/apps/cli/src/lib/preferences.ts
+++ b/apps/cli/src/lib/preferences.ts
@@ -25,8 +25,8 @@ export const DEFAULT_PREFERENCES: Preferences = {
  * Read all preferences from the DB and merge with defaults. Validation is
  * per-field — invalid values fall back to defaults silently.
  */
-export function loadPreferences(): Effect.Effect<Preferences, Error> {
-  return Effect.try({
+export const loadPreferences = (): Effect.Effect<Preferences, Error> =>
+  Effect.try({
     try: () => {
       const db = getDb();
       const stored = db.preferences.getAll();
@@ -34,20 +34,18 @@ export function loadPreferences(): Effect.Effect<Preferences, Error> {
     },
     catch: toError,
   });
-}
 
 /**
  * Write a partial preferences update. Only the supplied keys are touched;
  * other rows in the DB are left intact (no full-row read-modify-write needed).
  */
-export function savePreferences(
+export const savePreferences = (
   partial: Partial<Preferences>,
-): Effect.Effect<void, Error> {
-  return Effect.try({
+): Effect.Effect<void, Error> =>
+  Effect.try({
     try: () => {
       const db = getDb();
       db.preferences.setMany(partial as Record<string, unknown>);
     },
     catch: toError,
   });
-}

--- a/apps/cli/src/lib/python-bootstrap.ts
+++ b/apps/cli/src/lib/python-bootstrap.ts
@@ -26,42 +26,40 @@ export interface RunUvSyncOptions {
 /** Run `uv sync --extra dev` inside `${repoRoot}/python`. Streams output via onLine. */
 export function runUvSync(opts: RunUvSyncOptions): Effect.Effect<void, Error> {
   const cwd = join(opts.repoRoot, "python");
-  if (!existsSync(cwd)) {
-    return Effect.fail(new Error(`python directory not found at ${cwd}`));
-  }
+  return !existsSync(cwd)
+    ? Effect.fail(new Error(`python directory not found at ${cwd}`))
+    : Effect.tryPromise({
+        try: () =>
+          new Promise<void>((resolveP, rejectP) => {
+            const child = spawn("uv", ["sync", "--extra", "dev"], {
+              cwd,
+              env: process.env,
+              stdio: ["ignore", "pipe", "pipe"],
+            });
 
-  return Effect.tryPromise({
-    try: () =>
-      new Promise<void>((resolveP, rejectP) => {
-        const child = spawn("uv", ["sync", "--extra", "dev"], {
-          cwd,
-          env: process.env,
-          stdio: ["ignore", "pipe", "pipe"],
-        });
+            const pump = (chunk: Buffer) => {
+              for (const line of chunk.toString().split(/\r?\n/)) {
+                if (line.length > 0) opts.onLine(line);
+              }
+            };
+            child.stdout.on("data", pump);
+            child.stderr.on("data", pump);
 
-        const pump = (chunk: Buffer) => {
-          for (const line of chunk.toString().split(/\r?\n/)) {
-            if (line.length > 0) opts.onLine(line);
-          }
-        };
-        child.stdout.on("data", pump);
-        child.stderr.on("data", pump);
+            const onAbort = () => child.kill("SIGTERM");
+            opts.signal?.addEventListener("abort", onAbort, { once: true });
 
-        const onAbort = () => child.kill("SIGTERM");
-        opts.signal?.addEventListener("abort", onAbort, { once: true });
-
-        child.on("error", (err) => {
-          opts.signal?.removeEventListener("abort", onAbort);
-          rejectP(err);
-        });
-        child.on("close", (code) => {
-          opts.signal?.removeEventListener("abort", onAbort);
-          if (code === 0) resolveP();
-          else rejectP(new Error(`uv sync exited with code ${code}`));
-        });
-      }),
-    catch: toError,
-  });
+            child.on("error", (err) => {
+              opts.signal?.removeEventListener("abort", onAbort);
+              rejectP(err);
+            });
+            child.on("close", (code) => {
+              opts.signal?.removeEventListener("abort", onAbort);
+              if (code === 0) resolveP();
+              else rejectP(new Error(`uv sync exited with code ${code}`));
+            });
+          }),
+        catch: toError,
+      });
 }
 
 /** Quick check: does `${repoRoot}/python/.venv/bin/python` exist? */

--- a/apps/cli/src/lib/system-check.ts
+++ b/apps/cli/src/lib/system-check.ts
@@ -34,6 +34,5 @@ export function checkSystemBinary(name: SystemBinary): SystemBinaryStatus {
   };
 }
 
-export function checkSystemBinaries(): SystemBinaryStatus[] {
-  return (["uv", "ffmpeg", "espeak-ng"] as const).map(checkSystemBinary);
-}
+export const checkSystemBinaries = (): SystemBinaryStatus[] =>
+  (["uv", "ffmpeg", "espeak-ng"] as const).map(checkSystemBinary);

--- a/apps/cli/src/list-filter.ts
+++ b/apps/cli/src/list-filter.ts
@@ -5,6 +5,7 @@ export function filterBySubstring<T>(
   getSearchText: (item: T) => string,
 ): T[] {
   const q = query.trim().toLowerCase();
-  if (!q) return [...items];
-  return items.filter((item) => getSearchText(item).toLowerCase().includes(q));
+  return !q
+    ? [...items]
+    : items.filter((item) => getSearchText(item).toLowerCase().includes(q));
 }

--- a/apps/cli/src/list-nav.ts
+++ b/apps/cli/src/list-nav.ts
@@ -1,11 +1,7 @@
 /** Cyclic list index: `delta` is −1 / +1 for up/down. */
-export function cycleIndex(index: number, length: number, delta: number) {
-  if (length <= 0) return 0;
-  return (index + length + delta) % length;
-}
+export const cycleIndex = (index: number, length: number, delta: number) =>
+  length <= 0 ? 0 : (index + length + delta) % length;
 
 /** Clamp raw selection to `[0, length − 1]`; `0` if list empty. */
-export function clampSelectedIndex(selectedIndex: number, length: number) {
-  if (length <= 0) return 0;
-  return Math.min(Math.max(0, selectedIndex), length - 1);
-}
+export const clampSelectedIndex = (selectedIndex: number, length: number) =>
+  length <= 0 ? 0 : Math.min(Math.max(0, selectedIndex), length - 1);

--- a/apps/cli/src/list-selection-prefix.ts
+++ b/apps/cli/src/list-selection-prefix.ts
@@ -1,6 +1,5 @@
 export const LIST_SELECTED_PREFIX = "› ";
 export const LIST_UNSELECTED_PREFIX = "  ";
 
-export function listSelectionPrefix(selected: boolean) {
-  return selected ? LIST_SELECTED_PREFIX : LIST_UNSELECTED_PREFIX;
-}
+export const listSelectionPrefix = (selected: boolean) =>
+  selected ? LIST_SELECTED_PREFIX : LIST_UNSELECTED_PREFIX;

--- a/apps/cli/src/screens/chat/components/event-stream-view.tsx
+++ b/apps/cli/src/screens/chat/components/event-stream-view.tsx
@@ -40,11 +40,18 @@ const isErrorEvent = (event: ChatEvent) =>
   (event.type === "run.end" && event.status === "error");
 
 function eventMatchesFilter(event: ChatEvent, filter: EventFilter) {
-  if (filter === "all") return true;
-  if (filter === "messages") return isMessageEvent(event);
-  if (filter === "tools") return isToolEvent(event);
-  if (filter === "audio") return isAudioEvent(event);
-  if (filter === "errors") return isErrorEvent(event);
+  switch (filter) {
+    case "all":
+      return true;
+    case "messages":
+      return isMessageEvent(event);
+    case "tools":
+      return isToolEvent(event);
+    case "audio":
+      return isAudioEvent(event);
+    case "errors":
+      return isErrorEvent(event);
+  }
   return event.type === "system";
 }
 
@@ -126,9 +133,8 @@ function eventColor(event: ChatEvent) {
     return semantic.accent;
 }
 
-function eventDetailLines(event: ChatEvent) {
-  return JSON.stringify(event, null, 2).split("\n").slice(0, DETAIL_MAX_LINES);
-}
+const eventDetailLines = (event: ChatEvent) =>
+  JSON.stringify(event, null, 2).split("\n").slice(0, DETAIL_MAX_LINES);
 
 function nextEventFilter(current: EventFilter): EventFilter {
   const index = EVENT_FILTERS.indexOf(current);

--- a/apps/cli/src/screens/chat/components/message-bubble.tsx
+++ b/apps/cli/src/screens/chat/components/message-bubble.tsx
@@ -9,27 +9,25 @@ export interface MessageBubbleProps {
   borderColor: "green" | "cyan" | "gray";
 }
 
-export function MessageBubble({
+export const MessageBubble = ({
   content,
   label,
   borderColor,
-}: MessageBubbleProps) {
-  return (
-    <Box flexDirection="column" marginBottom={1}>
-      <Box marginBottom={0} marginLeft={0}>
-        <Text bold color={borderColor}>
-          {label}
-        </Text>
-      </Box>
-      <Box
-        borderStyle="round"
-        borderColor={borderColor}
-        paddingX={1}
-        paddingY={0}
-        marginTop={0}
-      >
-        <Markdown>{content}</Markdown>
-      </Box>
+}: MessageBubbleProps) => (
+  <Box flexDirection="column" marginBottom={1}>
+    <Box marginBottom={0} marginLeft={0}>
+      <Text bold color={borderColor}>
+        {label}
+      </Text>
     </Box>
-  );
-}
+    <Box
+      borderStyle="round"
+      borderColor={borderColor}
+      paddingX={1}
+      paddingY={0}
+      marginTop={0}
+    >
+      <Markdown>{content}</Markdown>
+    </Box>
+  </Box>
+);

--- a/apps/cli/src/screens/chat/components/slash-command-input.tsx
+++ b/apps/cli/src/screens/chat/components/slash-command-input.tsx
@@ -44,18 +44,18 @@ export function SlashCommandInput({
   useInput((input, key) => {
     const effectiveKey = getEffectiveKey(input, key as ExtendedKey);
 
-    if (effectiveKey === "return") {
-      const pick = n > 0 ? list[effectiveIndex] : undefined;
-      onSubmitLine(value, pick?.name);
-      return;
-    }
-    if (effectiveKey === "upArrow") {
-      setSelectedIndex((i) => cycleIndex(i, n, -1));
-      return;
-    }
-    if (effectiveKey === "downArrow") {
-      setSelectedIndex((i) => cycleIndex(i, n, 1));
-      return;
+    switch (effectiveKey) {
+      case "return": {
+        const pick = n > 0 ? list[effectiveIndex] : undefined;
+        onSubmitLine(value, pick?.name);
+        return;
+      }
+      case "upArrow":
+        setSelectedIndex((i) => cycleIndex(i, n, -1));
+        return;
+      case "downArrow":
+        setSelectedIndex((i) => cycleIndex(i, n, 1));
+        return;
     }
     if (effectiveKey === "backspace" || key.backspace) {
       setSelectedIndex(0);

--- a/apps/cli/src/screens/chat/event-persistence.ts
+++ b/apps/cli/src/screens/chat/event-persistence.ts
@@ -21,24 +21,25 @@ const DURABLE_EVENT_TYPES = new Set<ChatEvent["type"]>([
 export const isDurableChatEvent = (event: ChatEvent) =>
   DURABLE_EVENT_TYPES.has(event.type);
 
-export function persistChatEvent(event: ChatEvent): Effect.Effect<void, Error> {
-  if (!isDurableChatEvent(event)) return Effect.void;
-
-  return Effect.try({
-    try: () => {
-      const db = getDb();
-      db.agentEvents.append({
-        id: event.id,
-        conversationId: event.conversationId,
-        runId: event.runId,
-        type: event.type,
-        eventJson: JSON.stringify(event),
-        createdAt: event.timestamp,
+export const persistChatEvent = (
+  event: ChatEvent,
+): Effect.Effect<void, Error> =>
+  !isDurableChatEvent(event)
+    ? Effect.void
+    : Effect.try({
+        try: () => {
+          const db = getDb();
+          db.agentEvents.append({
+            id: event.id,
+            conversationId: event.conversationId,
+            runId: event.runId,
+            type: event.type,
+            eventJson: JSON.stringify(event),
+            createdAt: event.timestamp,
+          });
+        },
+        catch: toError,
       });
-    },
-    catch: toError,
-  });
-}
 
 /** Parse a persisted row, dropping malformed JSON or shape mismatches. */
 function parsePersistedEvent(eventJson: string): ChatEvent | null {
@@ -55,10 +56,10 @@ function parsePersistedEvent(eventJson: string): ChatEvent | null {
   }
 }
 
-export function listPersistedChatEvents(
+export const listPersistedChatEvents = (
   conversationId: string,
-): Effect.Effect<ChatEvent[], Error> {
-  return Effect.try({
+): Effect.Effect<ChatEvent[], Error> =>
+  Effect.try({
     try: () => {
       const db = getDb();
       return db.agentEvents
@@ -68,4 +69,3 @@ export function listPersistedChatEvents(
     },
     catch: toError,
   });
-}

--- a/apps/cli/src/screens/chat/events.ts
+++ b/apps/cli/src/screens/chat/events.ts
@@ -139,13 +139,12 @@ export const createMessageId = () => `msg_${randomId()}`;
 export const createToolCallId = (runId: string, name: string) =>
   `${runId}:tool:${name}:${randomId()}`;
 
-export function createChatEvent(input: ChatEventInput): ChatEvent {
-  return {
+export const createChatEvent = (input: ChatEventInput): ChatEvent =>
+  ({
     id: randomId(),
     timestamp: Date.now(),
     ...input,
-  } as ChatEvent;
-}
+  }) as ChatEvent;
 
 export function appendChatEvent(
   events: ChatEvent[],

--- a/apps/cli/src/screens/chat/slash-commands.ts
+++ b/apps/cli/src/screens/chat/slash-commands.ts
@@ -125,22 +125,21 @@ for (const cmd of SLASH_COMMANDS) {
   }
 }
 
-export function listSlashCommands() {
-  return SLASH_COMMANDS;
-}
+export const listSlashCommands = () => SLASH_COMMANDS;
 
 export function filterSlashCommands(query: string) {
   const q = query.trim().toLowerCase();
-  if (!q) return [...SLASH_COMMANDS];
-  return SLASH_COMMANDS.filter(
-    (c) =>
-      c.name.startsWith(q) || Boolean(c.aliases?.some((a) => a.startsWith(q))),
-  );
+  return !q
+    ? [...SLASH_COMMANDS]
+    : SLASH_COMMANDS.filter(
+        (c) =>
+          c.name.startsWith(q) ||
+          Boolean(c.aliases?.some((a) => a.startsWith(q))),
+      );
 }
 
-export function resolveSlashCommand(token: string) {
-  return SLASH_BY_TOKEN.get(token.toLowerCase());
-}
+export const resolveSlashCommand = (token: string) =>
+  SLASH_BY_TOKEN.get(token.toLowerCase());
 
 export function resolveSlashSubmit(
   rawLine: string,

--- a/apps/cli/src/screens/chat/store.tsx
+++ b/apps/cli/src/screens/chat/store.tsx
@@ -545,8 +545,8 @@ export function useChatController(initialState?: ChatStoreInitialState) {
     quit();
   }, [stopStt, stopChat]);
 
-  const buildSlashContext = useCallback((): SlashCommandContext => {
-    return {
+  const buildSlashContext = useCallback(
+    (): SlashCommandContext => ({
       clearConversation,
       stopChat,
       stopStt,
@@ -576,18 +576,19 @@ export function useChatController(initialState?: ChatStoreInitialState) {
       model,
       provider,
       voice,
-    };
-  }, [
-    clearConversation,
-    stopChat,
-    stopStt,
-    quitApp,
-    onBack,
-    onNavigate,
-    model,
-    provider,
-    voice,
-  ]);
+    }),
+    [
+      clearConversation,
+      stopChat,
+      stopStt,
+      quitApp,
+      onBack,
+      onNavigate,
+      model,
+      provider,
+      voice,
+    ],
+  );
 
   const handleComposerSubmit = useCallback(
     (raw: string, slashPick?: string) => {

--- a/apps/cli/src/screens/main-menu/components/menu.tsx
+++ b/apps/cli/src/screens/main-menu/components/menu.tsx
@@ -9,18 +9,16 @@ export interface MenuProps {
   selectedIndex: number;
 }
 
-export function Menu({ items, selectedIndex }: MenuProps) {
-  return (
-    <Box flexDirection="column" gap={0}>
-      {items.map((item, i) => (
-        <Box key={item.id}>
-          <Text color={i === selectedIndex ? semantic.accent : undefined}>
-            {listSelectionPrefix(i === selectedIndex)}
-            {item.label}
-          </Text>
-          {item.done && <Text color={semantic.success}> ✓</Text>}
-        </Box>
-      ))}
-    </Box>
-  );
-}
+export const Menu = ({ items, selectedIndex }: MenuProps) => (
+  <Box flexDirection="column" gap={0}>
+    {items.map((item, i) => (
+      <Box key={item.id}>
+        <Text color={i === selectedIndex ? semantic.accent : undefined}>
+          {listSelectionPrefix(i === selectedIndex)}
+          {item.label}
+        </Text>
+        {item.done && <Text color={semantic.success}> ✓</Text>}
+      </Box>
+    ))}
+  </Box>
+);

--- a/apps/cli/src/screens/settings/chat-model-row.ts
+++ b/apps/cli/src/screens/settings/chat-model-row.ts
@@ -7,8 +7,9 @@ export function chatModelRowText(p: {
   defaultChatModel: string;
 }): string {
   if (p.defaultChatProvider === "openrouter") {
-    if (p.openRouterModelsLoading) return "…";
-    return p.defaultChatModel || "(set API key, then pick model)";
+    return p.openRouterModelsLoading
+      ? "…"
+      : p.defaultChatModel || "(set API key, then pick model)";
   }
   if (p.modelsLoading) return "…";
   return p.defaultChatModel;

--- a/apps/cli/src/screens/settings/components/settings-main-list.tsx
+++ b/apps/cli/src/screens/settings/components/settings-main-list.tsx
@@ -29,8 +29,9 @@ function speechEndpointLabel(
         `OpenAI-compatible · ${prefs.voice.speech.kind === "openai-compatible" ? prefs.voice.speech.baseUrl : ""}`,
     )
     .exhaustive();
-  if (!health || prefs.voice.speech.kind !== "yappr") return baseLabel;
-  return `${baseLabel} (tts=${health.ttsBackend ?? "—"} · stt=${health.sttBackend ?? "—"})`;
+  return !health || prefs.voice.speech.kind !== "yappr"
+    ? baseLabel
+    : `${baseLabel} (tts=${health.ttsBackend ?? "—"} · stt=${health.sttBackend ?? "—"})`;
 }
 
 /** Main settings rows when no picker is open. */

--- a/apps/cli/src/screens/settings/store.tsx
+++ b/apps/cli/src/screens/settings/store.tsx
@@ -58,18 +58,18 @@ const SPEECH_ENDPOINT_VALUES: readonly SpeechPresetKind[] = [
 
 type SpeechEndpointPreset = SpeechPresetKind;
 
-function applySpeechPreset(kind: SpeechPresetKind): {
+const applySpeechPreset = (
+  kind: SpeechPresetKind,
+): {
   voice: VoiceConfig;
   defaultVoice?: string;
-} {
-  return {
-    voice: VoiceConfigSchema.parse({
-      speech: buildSpeechPreset(kind),
-      transcription: { kind: "yappr", baseUrl: DEFAULT_SERVER_URL },
-    }),
-    ...(kind === "voxtral" ? { defaultVoice: VOXTRAL_DEFAULT_VOICE } : {}),
-  };
-}
+} => ({
+  voice: VoiceConfigSchema.parse({
+    speech: buildSpeechPreset(kind),
+    transcription: { kind: "yappr", baseUrl: DEFAULT_SERVER_URL },
+  }),
+  ...(kind === "voxtral" ? { defaultVoice: VOXTRAL_DEFAULT_VOICE } : {}),
+});
 
 type PickerKindNonNull = Exclude<PickerKind, null>;
 
@@ -185,20 +185,15 @@ function nextVoiceReference(
 ): Preferences["voiceReference"] {
   const audio_path = patch.audio_path ?? prefs.voiceReference?.audio_path ?? "";
   const transcript = patch.transcript ?? prefs.voiceReference?.transcript ?? "";
-  if (!audio_path && !transcript) return null;
-  return { audio_path, transcript };
+  return !audio_path && !transcript ? null : { audio_path, transcript };
 }
 
 export interface SettingsStoreInitialState {
   onBack: () => void;
 }
 
-function clampPickerScrollOffset(index: number, listLength: number): number {
-  return Math.max(
-    0,
-    Math.min(index, Math.max(0, listLength - VISIBLE_PICKER_ROWS)),
-  );
-}
+const clampPickerScrollOffset = (index: number, listLength: number): number =>
+  Math.max(0, Math.min(index, Math.max(0, listLength - VISIBLE_PICKER_ROWS)));
 
 export const CHAT_PROVIDER_LABEL: Record<ChatProvider, string> = {
   ollama: PROVIDER_LABELS[0],
@@ -213,13 +208,11 @@ export function pickerItemLabel(item: PickerListItem): string {
   return id ? `${id} ${name}`.trim() : name;
 }
 
-function filterPickerList(
+const filterPickerList = (
   list: readonly PickerListItem[] | null,
   query: string,
-): PickerListItem[] {
-  if (!list?.length) return [];
-  return filterBySubstring(list, query, pickerItemLabel);
-}
+): PickerListItem[] =>
+  !list?.length ? [] : filterBySubstring(list, query, pickerItemLabel);
 
 function commitPickerChoice(
   kind: PickerKindNonNull,

--- a/apps/cli/src/screens/setup/speech-step.tsx
+++ b/apps/cli/src/screens/setup/speech-step.tsx
@@ -65,9 +65,8 @@ const TRANSCRIPTION_YAPPR: VoiceConfigInput["transcription"] = {
   baseUrl: DEFAULT_SERVER_URL,
 };
 
-function parseVoiceConfig(input: VoiceConfigInput): VoiceConfig {
-  return VoiceConfigSchema.parse(input);
-}
+const parseVoiceConfig = (input: VoiceConfigInput): VoiceConfig =>
+  VoiceConfigSchema.parse(input);
 
 export function SpeechStep({ onPick, onSkip }: SpeechStepProps) {
   const [phase, setPhase] = useState<Phase>("select");

--- a/apps/cli/src/screens/voices/screen.tsx
+++ b/apps/cli/src/screens/voices/screen.tsx
@@ -26,10 +26,12 @@ function VoicesPreviewStatusLine({
   return null;
 }
 
-function EmptyVoicesMessage({ voices }: { voices: readonly string[] }) {
-  if (voices.length === 0) return <Text dimColor>No voices returned.</Text>;
-  return <Text dimColor>No voices match filter.</Text>;
-}
+const EmptyVoicesMessage = ({ voices }: { voices: readonly string[] }) =>
+  voices.length === 0 ? (
+    <Text dimColor>No voices returned.</Text>
+  ) : (
+    <Text dimColor>No voices match filter.</Text>
+  );
 
 export function VoicesScreen({ onBack }: VoicesScreenProps) {
   const {

--- a/apps/cli/src/screens/voices/store.tsx
+++ b/apps/cli/src/screens/voices/store.tsx
@@ -153,31 +153,27 @@ export function useVoicesController(initialState?: VoicesStoreInitialState) {
       return;
     }
 
-    if (effectiveKey === "ctrl+e") {
-      if (phraseCustom) {
-        setPhraseCustom(false);
-      } else {
-        setPhrase((p) => (p.trim() ? p : VOICE_PREVIEW_SAMPLE));
-        setPhraseCustom(true);
-      }
-      return;
-    }
-
-    if (effectiveKey === "ctrl+p") {
-      playPreview(VOICE_PREVIEW_SAMPLE);
-      return;
-    }
-
-    if (
-      effectiveKey === "return" ||
-      effectiveKey === "enter" ||
-      effectiveKey === "ctrl+s"
-    ) {
-      if (phraseCustom) {
-        playPreview(phrase.trim() || VOICE_PREVIEW_SAMPLE);
-      } else {
+    switch (effectiveKey) {
+      case "ctrl+e":
+        if (phraseCustom) {
+          setPhraseCustom(false);
+        } else {
+          setPhrase((p) => (p.trim() ? p : VOICE_PREVIEW_SAMPLE));
+          setPhraseCustom(true);
+        }
+        return;
+      case "ctrl+p":
         playPreview(VOICE_PREVIEW_SAMPLE);
-      }
+        return;
+      case "return":
+      case "enter":
+      case "ctrl+s":
+        if (phraseCustom) {
+          playPreview(phrase.trim() || VOICE_PREVIEW_SAMPLE);
+        } else {
+          playPreview(VOICE_PREVIEW_SAMPLE);
+        }
+        break;
     }
   });
 

--- a/apps/cli/src/services/clipboard.ts
+++ b/apps/cli/src/services/clipboard.ts
@@ -56,12 +56,11 @@ export function readClipboardImage(): Effect.Effect<string | null, Error> {
   });
 }
 
-export function imagePathExists(path: string): Effect.Effect<boolean, Error> {
-  return Effect.tryPromise({
+export const imagePathExists = (path: string): Effect.Effect<boolean, Error> =>
+  Effect.tryPromise({
     try: () =>
       access(path)
         .then(() => true)
         .catch(() => false),
     catch: toError,
   });
-}

--- a/apps/cli/src/services/yappr/audio.ts
+++ b/apps/cli/src/services/yappr/audio.ts
@@ -22,9 +22,8 @@ export function stopAudioPlayback(): void {
   getDefaultAudioRuntime().playback.stop();
 }
 
-export function listVoices(): Effect.Effect<string[], Error> {
-  return listVoicesWithRuntime(getDefaultAudioRuntime());
-}
+export const listVoices = (): Effect.Effect<string[], Error> =>
+  listVoicesWithRuntime(getDefaultAudioRuntime());
 
 export function listVoicesWithRuntime(
   runtime: AudioRuntime,
@@ -32,12 +31,11 @@ export function listVoicesWithRuntime(
   return runtime.tts.listVoices();
 }
 
-export function speak(
+export const speak = (
   text: string,
   options: SpeakOptions = {},
-): Effect.Effect<void, Error> {
-  return speakWithRuntime(text, options, getDefaultAudioRuntime());
-}
+): Effect.Effect<void, Error> =>
+  speakWithRuntime(text, options, getDefaultAudioRuntime());
 
 export function speakWithRuntime(
   text: string,

--- a/apps/cli/src/services/yappr/chat/adapters/ollama-transport.ts
+++ b/apps/cli/src/services/yappr/chat/adapters/ollama-transport.ts
@@ -8,17 +8,15 @@ export interface OllamaTransportConfig {
 }
 
 /** {@link ChatTransport} for Ollama via `@tanstack/ai-ollama`. */
-export function createOllamaChatTransport(
+export const createOllamaChatTransport = (
   runtime: ChatRuntime,
   config: OllamaTransportConfig,
-): ChatTransport {
-  return {
-    name: "ollama",
-    stream: (req: ChatStreamRequest) =>
-      streamTanstackChat(
-        runtime,
-        runtime.createOllamaChat(config.model, config.baseUrl),
-        req,
-      ),
-  };
-}
+): ChatTransport => ({
+  name: "ollama",
+  stream: (req: ChatStreamRequest) =>
+    streamTanstackChat(
+      runtime,
+      runtime.createOllamaChat(config.model, config.baseUrl),
+      req,
+    ),
+});

--- a/apps/cli/src/services/yappr/chat/adapters/openrouter-transport.ts
+++ b/apps/cli/src/services/yappr/chat/adapters/openrouter-transport.ts
@@ -13,22 +13,20 @@ export interface OpenRouterTransportConfig {
  * agent loop + usage telemetry work uniformly (the previous bespoke SSE client
  * dropped tools).
  */
-export function createOpenRouterChatTransport(
+export const createOpenRouterChatTransport = (
   runtime: ChatRuntime,
   config: OpenRouterTransportConfig,
-): ChatTransport {
-  return {
-    name: "openrouter",
-    stream: (req: ChatStreamRequest) =>
-      streamTanstackChat(
-        runtime,
-        // OpenRouter model ids are user-configured; the adapter's model union
-        // is autocomplete-only, so accept any string.
-        runtime.createOpenRouterText(
-          config.model as Parameters<ChatRuntime["createOpenRouterText"]>[0],
-          config.apiKey,
-        ),
-        req,
+): ChatTransport => ({
+  name: "openrouter",
+  stream: (req: ChatStreamRequest) =>
+    streamTanstackChat(
+      runtime,
+      // OpenRouter model ids are user-configured; the adapter's model union
+      // is autocomplete-only, so accept any string.
+      runtime.createOpenRouterText(
+        config.model as Parameters<ChatRuntime["createOpenRouterText"]>[0],
+        config.apiKey,
       ),
-  };
-}
+      req,
+    ),
+});

--- a/apps/cli/src/services/yappr/chat/runtime.ts
+++ b/apps/cli/src/services/yappr/chat/runtime.ts
@@ -13,14 +13,12 @@ export interface ChatRuntime {
   getOllamaClient: typeof getOllamaClient;
 }
 
-export function createDefaultChatRuntime(): ChatRuntime {
-  return {
-    createMcpManager: () => new McpManager(),
-    tanstackChat,
-    createOllamaChat,
-    createOpenRouterText,
-    getOllamaClient,
-  };
-}
+export const createDefaultChatRuntime = (): ChatRuntime => ({
+  createMcpManager: () => new McpManager(),
+  tanstackChat,
+  createOllamaChat,
+  createOpenRouterText,
+  getOllamaClient,
+});
 
 export const defaultChatRuntime: ChatRuntime = createDefaultChatRuntime();

--- a/apps/cli/src/services/yappr/chat/transport.ts
+++ b/apps/cli/src/services/yappr/chat/transport.ts
@@ -47,11 +47,11 @@ export interface ChatTransportConfig {
  * Adding a new provider = new adapter file + new branch here; the
  * orchestrator code does not change.
  */
-export function createChatTransport(
+export const createChatTransport = (
   runtime: ChatRuntime,
   config: ChatTransportConfig,
-): ChatTransport {
-  return match(config.provider)
+): ChatTransport =>
+  match(config.provider)
     .with("openrouter", () =>
       createOpenRouterChatTransport(runtime, {
         model: config.model,
@@ -65,4 +65,3 @@ export function createChatTransport(
       }),
     )
     .exhaustive();
-}

--- a/apps/cli/src/services/yappr/ollama.ts
+++ b/apps/cli/src/services/yappr/ollama.ts
@@ -6,8 +6,9 @@ export const DEFAULT_OLLAMA_URL = "http://localhost:11434";
 
 export function getOllamaClient(baseUrl?: string): Ollama {
   const url = baseUrl?.trim() || DEFAULT_OLLAMA_URL;
-  if (url === DEFAULT_OLLAMA_URL) return ollama as Ollama;
-  return new Ollama({ host: url });
+  return url === DEFAULT_OLLAMA_URL
+    ? (ollama as Ollama)
+    : new Ollama({ host: url });
 }
 
 export function listOllamaModels(

--- a/apps/cli/src/services/yappr/openrouter.ts
+++ b/apps/cli/src/services/yappr/openrouter.ts
@@ -46,31 +46,29 @@ async function throwOpenRouterHttpError(res: Response): Promise<never> {
  * List tool-capable OpenRouter models for the settings picker. Chat itself
  * goes through `@tanstack/ai-openrouter` (see chat/runtime.ts), not this file.
  */
-export function listOpenRouterModels(
+export const listOpenRouterModels = (
   apiKey: string,
-): Effect.Effect<OpenRouterModelInfo[], Error> {
-  if (!apiKey.trim()) {
-    return Effect.succeed([]);
-  }
-  return Effect.tryPromise({
-    try: async () => {
-      const res = await fetch(
-        `${OPENROUTER_BASE}/models?supported_parameters=tools`,
-        {
-          headers: { Authorization: `Bearer ${apiKey.trim()}` },
+): Effect.Effect<OpenRouterModelInfo[], Error> =>
+  !apiKey.trim()
+    ? Effect.succeed([])
+    : Effect.tryPromise({
+        try: async () => {
+          const res = await fetch(
+            `${OPENROUTER_BASE}/models?supported_parameters=tools`,
+            {
+              headers: { Authorization: `Bearer ${apiKey.trim()}` },
+            },
+          );
+          if (!res.ok) await throwOpenRouterHttpError(res);
+          const json = (await res.json()) as OpenRouterModelsApiResponse;
+          const list = json.data ?? [];
+          return list
+            .filter(isUsableOpenRouterModel)
+            .map((m) => ({
+              id: m.id,
+              name: m.name ?? m.id,
+            }))
+            .toSorted((a, b) => a.name.localeCompare(b.name));
         },
-      );
-      if (!res.ok) await throwOpenRouterHttpError(res);
-      const json = (await res.json()) as OpenRouterModelsApiResponse;
-      const list = json.data ?? [];
-      return list
-        .filter(isUsableOpenRouterModel)
-        .map((m) => ({
-          id: m.id,
-          name: m.name ?? m.id,
-        }))
-        .toSorted((a, b) => a.name.localeCompare(b.name));
-    },
-    catch: toError,
-  });
-}
+        catch: toError,
+      });

--- a/apps/desktop/src/bun/db-rpc.ts
+++ b/apps/desktop/src/bun/db-rpc.ts
@@ -31,63 +31,61 @@ type Handlers = {
  * The wire schema in `@yappr/db/rpc` is the contract — adding a method here
  * without updating the schema is a TS error on both sides.
  */
-export function makeDbRpcHandlers(db: YapprDb): Handlers {
-  return {
-    "preferences:getAll": () => db.preferences.getAll(),
-    "preferences:setMany": (entries) => {
-      db.preferences.setMany(PreferencesSetManyInput.parse(entries));
-    },
-    "conversations:list": (params) => {
-      const parsed = ConversationsListInput.parse(params);
-      const scope = parsed?.scope ?? "active";
-      return db.conversations.list(scope, { limit: parsed?.limit });
-    },
-    "conversations:get": (params) => {
-      const { id } = ConversationsGetInput.parse(params);
-      return db.conversations.get(id);
-    },
-    "conversations:create": (params) => {
-      const input = ConversationsCreateInput.parse(params);
-      return db.conversations.create(input);
-    },
-    "conversations:rename": (params) => {
-      const { id, title } = ConversationsRenameInput.parse(params);
-      db.conversations.rename(id, title);
-    },
-    "conversations:delete": (params) => {
-      const { id } = ConversationsDeleteInput.parse(params);
-      db.conversations.delete(id);
-    },
-    "conversations:setArchived": (params) => {
-      const { id, archived } = ConversationsSetArchivedInput.parse(params);
-      db.conversations.setArchived(id, archived);
-    },
-    "messages:list": (params) => {
-      const { conversationId, limit } = MessagesListInput.parse(params);
-      return db.messages.list(conversationId, { limit });
-    },
-    "messages:append": (params) => {
-      const input = MessagesAppendInput.parse(params);
-      return db.messages.append(input);
-    },
-    "messages:delete": (params) => {
-      const { id } = MessagesDeleteInput.parse(params);
-      db.messages.delete(id);
-    },
-    "agentEvents:listForConversation": (params) => {
-      const { conversationId, limit } =
-        AgentEventsListForConversationInput.parse(params);
-      return db.agentEvents.listForConversation(conversationId, {
-        limit,
-      });
-    },
-    "agentEvents:listForRun": (params) => {
-      const { runId, limit } = AgentEventsListForRunInput.parse(params);
-      return db.agentEvents.listForRun(runId, { limit });
-    },
-    "agentEvents:append": (params) => {
-      const input = AgentEventsAppendInput.parse(params);
-      return db.agentEvents.append(input);
-    },
-  };
-}
+export const makeDbRpcHandlers = (db: YapprDb): Handlers => ({
+  "preferences:getAll": () => db.preferences.getAll(),
+  "preferences:setMany": (entries) => {
+    db.preferences.setMany(PreferencesSetManyInput.parse(entries));
+  },
+  "conversations:list": (params) => {
+    const parsed = ConversationsListInput.parse(params);
+    const scope = parsed?.scope ?? "active";
+    return db.conversations.list(scope, { limit: parsed?.limit });
+  },
+  "conversations:get": (params) => {
+    const { id } = ConversationsGetInput.parse(params);
+    return db.conversations.get(id);
+  },
+  "conversations:create": (params) => {
+    const input = ConversationsCreateInput.parse(params);
+    return db.conversations.create(input);
+  },
+  "conversations:rename": (params) => {
+    const { id, title } = ConversationsRenameInput.parse(params);
+    db.conversations.rename(id, title);
+  },
+  "conversations:delete": (params) => {
+    const { id } = ConversationsDeleteInput.parse(params);
+    db.conversations.delete(id);
+  },
+  "conversations:setArchived": (params) => {
+    const { id, archived } = ConversationsSetArchivedInput.parse(params);
+    db.conversations.setArchived(id, archived);
+  },
+  "messages:list": (params) => {
+    const { conversationId, limit } = MessagesListInput.parse(params);
+    return db.messages.list(conversationId, { limit });
+  },
+  "messages:append": (params) => {
+    const input = MessagesAppendInput.parse(params);
+    return db.messages.append(input);
+  },
+  "messages:delete": (params) => {
+    const { id } = MessagesDeleteInput.parse(params);
+    db.messages.delete(id);
+  },
+  "agentEvents:listForConversation": (params) => {
+    const { conversationId, limit } =
+      AgentEventsListForConversationInput.parse(params);
+    return db.agentEvents.listForConversation(conversationId, {
+      limit,
+    });
+  },
+  "agentEvents:listForRun": (params) => {
+    const { runId, limit } = AgentEventsListForRunInput.parse(params);
+    return db.agentEvents.listForRun(runId, { limit });
+  },
+  "agentEvents:append": (params) => {
+    const input = AgentEventsAppendInput.parse(params);
+    return db.agentEvents.append(input);
+  },
+});

--- a/apps/desktop/src/mainview/app/components/composer.tsx
+++ b/apps/desktop/src/mainview/app/components/composer.tsx
@@ -88,16 +88,12 @@ export function Composer({
     setAttachBusy(true);
     try {
       const converted = await fileListToAttachments(list);
-      const sizedOk = converted.filter((p) => {
-        if (p.url.startsWith("data:")) {
-          return p.url.length <= MAX_FILE_BYTES * 2;
-        }
-        return true;
-      });
+      const sizedOk = converted.filter((p) =>
+        p.url.startsWith("data:") ? p.url.length <= MAX_FILE_BYTES * 2 : true,
+      );
       setPendingFiles((prev) => {
         const room = MAX_ATTACHMENTS - prev.length;
-        if (room <= 0) return prev;
-        return [...prev, ...sizedOk.slice(0, room)];
+        return room <= 0 ? prev : [...prev, ...sizedOk.slice(0, room)];
       });
     } finally {
       setAttachBusy(false);

--- a/apps/desktop/src/mainview/app/components/mic-button.tsx
+++ b/apps/desktop/src/mainview/app/components/mic-button.tsx
@@ -36,17 +36,16 @@ interface MicButtonProps {
   inputDeviceId?: string | null;
 }
 
-function getMicLabel(state: MicState) {
-  return match(state)
+const getMicLabel = (state: MicState) =>
+  match(state)
     .with({ kind: "idle" }, () => "Start dictation")
     .with({ kind: "recording" }, () => "Stop dictation")
     .with({ kind: "processing" }, () => "Transcribing…")
     .with({ kind: "error" }, ({ reason }) => `Mic error — ${reason}`)
     .exhaustive();
-}
 
-function MicStateIcon({ state }: { state: MicState }) {
-  return match(state)
+const MicStateIcon = ({ state }: { state: MicState }) =>
+  match(state)
     .with({ kind: "recording" }, () => (
       <Square className="size-3.5" aria-hidden="true" />
     ))
@@ -57,7 +56,6 @@ function MicStateIcon({ state }: { state: MicState }) {
       <Mic className="size-4" aria-hidden="true" />
     ))
     .exhaustive();
-}
 
 /**
  * Click-to-toggle dictation. Uses MediaRecorder + the Python /transcribe
@@ -77,9 +75,7 @@ export function MicButton({
   const streamRef = useRef<MediaStream | null>(null);
 
   // Always release the mic on unmount, even mid-recording.
-  useEffect(() => {
-    return () => releaseStream(streamRef.current);
-  }, []);
+  useEffect(() => () => releaseStream(streamRef.current), []);
 
   const start = useCallback(async () => {
     try {

--- a/apps/desktop/src/mainview/app/index.tsx
+++ b/apps/desktop/src/mainview/app/index.tsx
@@ -5,14 +5,12 @@ import { queryClient } from "~/lib/query-client";
 import { VoiceProvider } from "~/stores/voice";
 import { router } from "./router";
 
-function App() {
-  return (
-    <QueryClientProvider client={queryClient}>
-      <VoiceProvider>
-        <RouterProvider router={router} />
-      </VoiceProvider>
-    </QueryClientProvider>
-  );
-}
+const App = () => (
+  <QueryClientProvider client={queryClient}>
+    <VoiceProvider>
+      <RouterProvider router={router} />
+    </VoiceProvider>
+  </QueryClientProvider>
+);
 
 export default App;

--- a/apps/desktop/src/mainview/app/layout/main.tsx
+++ b/apps/desktop/src/mainview/app/layout/main.tsx
@@ -7,10 +7,8 @@ import { TooltipProvider } from "~/ui/tooltip";
  *   - ChatScreen mounts ChatLayout (sidebar + main column).
  * AppLayout only provides global providers that every route needs.
  */
-export function MainLayout() {
-  return (
-    <TooltipProvider delayDuration={250}>
-      <Outlet />
-    </TooltipProvider>
-  );
-}
+export const MainLayout = () => (
+  <TooltipProvider delayDuration={250}>
+    <Outlet />
+  </TooltipProvider>
+);

--- a/apps/desktop/src/mainview/app/screens/chat/components/karaoke-captions.tsx
+++ b/apps/desktop/src/mainview/app/screens/chat/components/karaoke-captions.tsx
@@ -86,10 +86,13 @@ export function KaraokeCaptions({
     () => (activeText && fontsReady ? prepareCaption(activeText) : null),
     [activeText, fontsReady],
   );
-  const layout = useMemo(() => {
-    if (!prepared || width <= 0) return null;
-    return layoutCaption(prepared, Math.max(1, width - 32), activeProgress);
-  }, [activeProgress, prepared, width]);
+  const layout = useMemo(
+    () =>
+      !prepared || width <= 0
+        ? null
+        : layoutCaption(prepared, Math.max(1, width - 32), activeProgress),
+    [activeProgress, prepared, width],
+  );
 
   if (!active) return null;
 

--- a/apps/desktop/src/mainview/app/screens/chat/components/layout.tsx
+++ b/apps/desktop/src/mainview/app/screens/chat/components/layout.tsx
@@ -8,13 +8,11 @@ import { ChatPanel } from "./panel";
 import { ChatSidebar } from "./sidebar";
 import { ChatTopBar } from "./top-bar";
 
-export function ChatLayout() {
-  return (
-    <ChatProvider>
-      <ChatLayoutContent />
-    </ChatProvider>
-  );
-}
+export const ChatLayout = () => (
+  <ChatProvider>
+    <ChatLayoutContent />
+  </ChatProvider>
+);
 
 function ChatLayoutContent() {
   const { store } = useChatContext();

--- a/apps/desktop/src/mainview/app/screens/chat/components/settings-sheet.tsx
+++ b/apps/desktop/src/mainview/app/screens/chat/components/settings-sheet.tsx
@@ -438,11 +438,10 @@ export function ChatSettingsSheet({ children }: ChatSettingsSheetProps) {
   );
 }
 
-const healthLine = (health: HealthState): string => {
-  return match(health)
+const healthLine = (health: HealthState): string =>
+  match(health)
     .with({ kind: "idle" }, () => "Not checked.")
     .with({ kind: "checking" }, () => "Probing…")
     .with({ kind: "ok" }, ({ voices }) => `Online — ${voices} voices.`)
     .with({ kind: "fail" }, ({ reason }) => `Error: ${reason}`)
     .exhaustive();
-};

--- a/apps/desktop/src/mainview/app/screens/chat/components/top-bar.tsx
+++ b/apps/desktop/src/mainview/app/screens/chat/components/top-bar.tsx
@@ -69,22 +69,18 @@ export function ChatTopBar({ model, onModelChange }: ChatTopBarProps) {
   );
 }
 
-const healthLabel = (kind: "idle" | "checking" | "ok" | "fail"): string => {
-  return match(kind)
+const healthLabel = (kind: "idle" | "checking" | "ok" | "fail"): string =>
+  match(kind)
     .with("ok", () => "online")
     .with("checking", () => "probing")
     .with("fail", () => "offline")
     .with("idle", () => "idle")
     .exhaustive();
-};
 
-const healthDescription = (
-  kind: "idle" | "checking" | "ok" | "fail",
-): string => {
-  return match(kind)
+const healthDescription = (kind: "idle" | "checking" | "ok" | "fail"): string =>
+  match(kind)
     .with("ok", () => "Inference server reachable")
     .with("checking", () => "Probing inference server…")
     .with("fail", () => "Inference server unreachable — open Settings")
     .with("idle", () => "Inference server not checked — open Settings to probe")
     .exhaustive();
-};

--- a/apps/desktop/src/mainview/app/screens/chat/screen.tsx
+++ b/apps/desktop/src/mainview/app/screens/chat/screen.tsx
@@ -1,5 +1,3 @@
 import { ChatLayout } from "./components/layout";
 
-export function ChatScreen() {
-  return <ChatLayout />;
-}
+export const ChatScreen = () => <ChatLayout />;

--- a/apps/desktop/src/mainview/hooks/use-input-devices.ts
+++ b/apps/desktop/src/mainview/hooks/use-input-devices.ts
@@ -20,10 +20,10 @@ export interface UseInputDevicesResult {
 
 const QUERY_KEY = ["audio-devices"] as const;
 
-async function fetchDevices(): Promise<MediaDeviceInfo[]> {
-  if (!navigator.mediaDevices?.enumerateDevices) return [];
-  return navigator.mediaDevices.enumerateDevices();
-}
+const fetchDevices = async (): Promise<MediaDeviceInfo[]> =>
+  !navigator.mediaDevices?.enumerateDevices
+    ? []
+    : navigator.mediaDevices.enumerateDevices();
 
 export function useInputDevices(): UseInputDevicesResult {
   const queryClient = useQueryClient();

--- a/apps/desktop/src/mainview/lib/captions.ts
+++ b/apps/desktop/src/mainview/lib/captions.ts
@@ -59,13 +59,14 @@ export const normalizeCaptionText = (text: string): string =>
 
 export const prepareCaption = (text: string): PreparedCaption | null => {
   const normalized = normalizeCaptionText(text);
-  if (!normalized) return null;
-  return {
-    text: normalized,
-    prepared: prepareWithSegments(normalized, CAPTION_FONT, {
-      whiteSpace: "pre-wrap",
-    }),
-  };
+  return !normalized
+    ? null
+    : {
+        text: normalized,
+        prepared: prepareWithSegments(normalized, CAPTION_FONT, {
+          whiteSpace: "pre-wrap",
+        }),
+      };
 };
 
 export const layoutCaption = (

--- a/apps/desktop/src/mainview/lib/message-bubble-layout.test.ts
+++ b/apps/desktop/src/mainview/lib/message-bubble-layout.test.ts
@@ -11,13 +11,14 @@ const installMeasureShim = () => {
     configurable: true,
     value: class {
       getContext(kind: string) {
-        if (kind !== "2d") return null;
-        return {
-          font: "",
-          measureText: (text: string) => ({
-            width: [...text].length * 8,
-          }),
-        } as OffscreenCanvasRenderingContext2D;
+        return kind !== "2d"
+          ? null
+          : ({
+              font: "",
+              measureText: (text: string) => ({
+                width: [...text].length * 8,
+              }),
+            } as OffscreenCanvasRenderingContext2D);
       }
     },
   });

--- a/apps/desktop/src/mainview/lib/queries.ts
+++ b/apps/desktop/src/mainview/lib/queries.ts
@@ -83,10 +83,10 @@ export const archivedConversationsOptions = queryOptions({
 export const messagesOptions = (conversationId: string | null) =>
   queryOptions({
     queryKey: ["db", "messages", conversationId] as const,
-    queryFn: () => {
-      if (!conversationId) return Promise.resolve([]);
-      return dbRpc.request("messages:list", { conversationId });
-    },
+    queryFn: () =>
+      !conversationId
+        ? Promise.resolve([])
+        : dbRpc.request("messages:list", { conversationId }),
     enabled: Boolean(conversationId),
     staleTime: Infinity, // streaming appends drive invalidation manually
   });

--- a/apps/desktop/src/mainview/lib/utils.ts
+++ b/apps/desktop/src/mainview/lib/utils.ts
@@ -1,6 +1,4 @@
 import { type ClassValue, clsx } from "clsx";
 import { twMerge } from "tailwind-merge";
 
-export function cn(...inputs: ClassValue[]) {
-  return twMerge(clsx(inputs));
-}
+export const cn = (...inputs: ClassValue[]) => twMerge(clsx(inputs));

--- a/apps/desktop/src/mainview/services/mcp/tools.ts
+++ b/apps/desktop/src/mainview/services/mcp/tools.ts
@@ -20,10 +20,10 @@ export const mcpToolsOptions = queryOptions({
 });
 
 /** Build `@tanstack/ai` tools whose execution is bridged to bun over RPC. */
-export function buildMcpTools(
+export const buildMcpTools = (
   metas: McpToolMeta[],
-): Array<Tool<SchemaInput, SchemaInput>> {
-  return metas.map((meta) => {
+): Array<Tool<SchemaInput, SchemaInput>> =>
+  metas.map((meta) => {
     const def = toolDefinition({
       name: meta.name,
       description: meta.description ?? "",
@@ -37,4 +37,3 @@ export function buildMcpTools(
       return result.content;
     });
   });
-}

--- a/apps/desktop/src/mainview/services/ollama/index.ts
+++ b/apps/desktop/src/mainview/services/ollama/index.ts
@@ -5,11 +5,10 @@
  * 127.0.0.1:11434, avoids CORS); in the packaged build we hit the loopback
  * daemon directly (relies on `OLLAMA_ORIGINS`).
  */
-export function ollamaRoot(): string {
-  return import.meta.env.DEV
+export const ollamaRoot = (): string =>
+  import.meta.env.DEV
     ? `${globalThis.location.origin}/ollama`
     : "http://127.0.0.1:11434";
-}
 
 /** Model entry returned by `GET /api/tags`. */
 export interface OllamaModel {

--- a/apps/desktop/src/mainview/services/ollama/transport.ts
+++ b/apps/desktop/src/mainview/services/ollama/transport.ts
@@ -26,11 +26,11 @@ type McpTools = Array<Tool<SchemaInput, SchemaInput>>;
  * multi-step agent loop is enabled (tools-only, matching the CLI); a tool-less
  * turn stays single-shot.
  */
-export function createOllamaConnection(
+export const createOllamaConnection = (
   getModel: () => string,
   getTools: () => McpTools = () => [],
-) {
-  return stream((messages, _data, abortSignal) => {
+) =>
+  stream((messages, _data, abortSignal) => {
     const adapter = createOllamaChat(getModel(), ollamaRoot());
     const abortController = new AbortController();
     if (abortSignal) {
@@ -51,4 +51,3 @@ export function createOllamaConnection(
       }),
     });
   });
-}

--- a/apps/desktop/src/mainview/ui/chat-container.tsx
+++ b/apps/desktop/src/mainview/ui/chat-container.tsx
@@ -16,50 +16,44 @@ export type ChatContainerContentProps = {
   className?: string;
 } & HTMLAttributes<HTMLDivElement>;
 
-function ChatContainerRoot({
+const ChatContainerRoot = ({
   children,
   className,
   ...props
-}: ChatContainerRootProps) {
-  return (
-    <StickToBottom
-      className={cn("flex overflow-y-auto", className)}
-      resize="smooth"
-      initial="instant"
-      role="log"
-      {...props}
-    >
-      {children}
-    </StickToBottom>
-  );
-}
+}: ChatContainerRootProps) => (
+  <StickToBottom
+    className={cn("flex overflow-y-auto", className)}
+    resize="smooth"
+    initial="instant"
+    role="log"
+    {...props}
+  >
+    {children}
+  </StickToBottom>
+);
 
-function ChatContainerContent({
+const ChatContainerContent = ({
   children,
   className,
   ...props
-}: ChatContainerContentProps) {
-  return (
-    <StickToBottom.Content
-      className={cn("flex w-full flex-col", className)}
-      {...props}
-    >
-      {children}
-    </StickToBottom.Content>
-  );
-}
+}: ChatContainerContentProps) => (
+  <StickToBottom.Content
+    className={cn("flex w-full flex-col", className)}
+    {...props}
+  >
+    {children}
+  </StickToBottom.Content>
+);
 
-function ChatContainerScrollAnchor({
+const ChatContainerScrollAnchor = ({
   className,
   ...props
-}: HTMLAttributes<HTMLDivElement>) {
-  return (
-    <div
-      className={cn("h-px w-full shrink-0 scroll-mt-4", className)}
-      aria-hidden="true"
-      {...props}
-    />
-  );
-}
+}: HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("h-px w-full shrink-0 scroll-mt-4", className)}
+    aria-hidden="true"
+    {...props}
+  />
+);
 
 export { ChatContainerContent, ChatContainerRoot, ChatContainerScrollAnchor };

--- a/apps/desktop/src/mainview/ui/code-block.tsx
+++ b/apps/desktop/src/mainview/ui/code-block.tsx
@@ -10,20 +10,18 @@ export type CodeBlockProps = {
   className?: string;
 } & React.HTMLProps<HTMLDivElement>;
 
-function CodeBlock({ children, className, ...props }: CodeBlockProps) {
-  return (
-    <div
-      className={cn(
-        "not-prose flex w-full flex-col overflow-clip border",
-        "border-border bg-card text-card-foreground rounded-xl",
-        className,
-      )}
-      {...props}
-    >
-      {children}
-    </div>
-  );
-}
+const CodeBlock = ({ children, className, ...props }: CodeBlockProps) => (
+  <div
+    className={cn(
+      "not-prose flex w-full flex-col overflow-clip border",
+      "border-border bg-card text-card-foreground rounded-xl",
+      className,
+    )}
+    {...props}
+  >
+    {children}
+  </div>
+);
 
 export type CodeBlockCodeProps = {
   code: string;
@@ -78,19 +76,17 @@ function CodeBlockCode({
 
 export type CodeBlockGroupProps = React.HTMLAttributes<HTMLDivElement>;
 
-function CodeBlockGroup({
+const CodeBlockGroup = ({
   children,
   className,
   ...props
-}: CodeBlockGroupProps) {
-  return (
-    <div
-      className={cn("flex items-center justify-between", className)}
-      {...props}
-    >
-      {children}
-    </div>
-  );
-}
+}: CodeBlockGroupProps) => (
+  <div
+    className={cn("flex items-center justify-between", className)}
+    {...props}
+  >
+    {children}
+  </div>
+);
 
 export { CodeBlock, CodeBlockCode, CodeBlockGroup };

--- a/apps/desktop/src/mainview/ui/command.tsx
+++ b/apps/desktop/src/mainview/ui/command.tsx
@@ -23,17 +23,15 @@ const Command = React.forwardRef<
 ));
 Command.displayName = CommandPrimitive.displayName;
 
-const CommandDialog = ({ children, ...props }: DialogProps) => {
-  return (
-    <Dialog {...props}>
-      <DialogContent className="overflow-hidden p-0">
-        <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
-          {children}
-        </Command>
-      </DialogContent>
-    </Dialog>
-  );
-};
+const CommandDialog = ({ children, ...props }: DialogProps) => (
+  <Dialog {...props}>
+    <DialogContent className="overflow-hidden p-0">
+      <Command className="[&_[cmdk-group-heading]]:px-2 [&_[cmdk-group-heading]]:font-medium [&_[cmdk-group-heading]]:text-muted-foreground [&_[cmdk-group]:not([hidden])_~[cmdk-group]]:pt-0 [&_[cmdk-group]]:px-2 [&_[cmdk-input-wrapper]_svg]:h-5 [&_[cmdk-input-wrapper]_svg]:w-5 [&_[cmdk-input]]:h-12 [&_[cmdk-item]]:px-2 [&_[cmdk-item]]:py-3 [&_[cmdk-item]_svg]:h-5 [&_[cmdk-item]_svg]:w-5">
+        {children}
+      </Command>
+    </DialogContent>
+  </Dialog>
+);
 
 const CommandInput = React.forwardRef<
   React.ElementRef<typeof CommandPrimitive.Input>,
@@ -127,17 +125,15 @@ CommandItem.displayName = CommandPrimitive.Item.displayName;
 const CommandShortcut = ({
   className,
   ...props
-}: React.HTMLAttributes<HTMLSpanElement>) => {
-  return (
-    <span
-      className={cn(
-        "ml-auto text-xs tracking-widest text-muted-foreground",
-        className,
-      )}
-      {...props}
-    />
-  );
-};
+}: React.HTMLAttributes<HTMLSpanElement>) => (
+  <span
+    className={cn(
+      "ml-auto text-xs tracking-widest text-muted-foreground",
+      className,
+    )}
+    {...props}
+  />
+);
 CommandShortcut.displayName = "CommandShortcut";
 
 export {

--- a/apps/desktop/src/mainview/ui/dropdown-menu.tsx
+++ b/apps/desktop/src/mainview/ui/dropdown-menu.tsx
@@ -170,14 +170,12 @@ DropdownMenuSeparator.displayName = DropdownMenuPrimitive.Separator.displayName;
 const DropdownMenuShortcut = ({
   className,
   ...props
-}: React.HTMLAttributes<HTMLSpanElement>) => {
-  return (
-    <span
-      className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
-      {...props}
-    />
-  );
-};
+}: React.HTMLAttributes<HTMLSpanElement>) => (
+  <span
+    className={cn("ml-auto text-xs tracking-widest opacity-60", className)}
+    {...props}
+  />
+);
 DropdownMenuShortcut.displayName = "DropdownMenuShortcut";
 
 export {

--- a/apps/desktop/src/mainview/ui/input.tsx
+++ b/apps/desktop/src/mainview/ui/input.tsx
@@ -3,19 +3,17 @@ import * as React from "react";
 import { cn } from "~/lib/utils";
 
 const Input = React.forwardRef<HTMLInputElement, React.ComponentProps<"input">>(
-  ({ className, type, ...props }, ref) => {
-    return (
-      <input
-        type={type}
-        className={cn(
-          "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-          className,
-        )}
-        ref={ref}
-        {...props}
-      />
-    );
-  },
+  ({ className, type, ...props }, ref) => (
+    <input
+      type={type}
+      className={cn(
+        "flex h-9 w-full rounded-md border border-input bg-transparent px-3 py-1 text-base shadow-sm transition-colors file:border-0 file:bg-transparent file:text-sm file:font-medium file:text-foreground placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+        className,
+      )}
+      ref={ref}
+      {...props}
+    />
+  ),
 );
 Input.displayName = "Input";
 

--- a/apps/desktop/src/mainview/ui/message.tsx
+++ b/apps/desktop/src/mainview/ui/message.tsx
@@ -38,16 +38,12 @@ const MessageAvatar = ({
   fallback,
   delayMs,
   className,
-}: MessageAvatarProps) => {
-  return (
-    <Avatar className={cn("h-8 w-8 shrink-0", className)}>
-      <AvatarImage src={src} alt={alt} />
-      {fallback && (
-        <AvatarFallback delayMs={delayMs}>{fallback}</AvatarFallback>
-      )}
-    </Avatar>
-  );
-};
+}: MessageAvatarProps) => (
+  <Avatar className={cn("h-8 w-8 shrink-0", className)}>
+    <AvatarImage src={src} alt={alt} />
+    {fallback && <AvatarFallback delayMs={delayMs}>{fallback}</AvatarFallback>}
+  </Avatar>
+);
 
 export type MessageContentProps = {
   children: React.ReactNode;
@@ -109,23 +105,21 @@ const MessageAction = ({
   className,
   side = "bottom",
   ...props
-}: MessageActionProps) => {
-  return (
-    <TooltipProvider>
-      <Tooltip {...props}>
-        <TooltipTrigger asChild>{children}</TooltipTrigger>
-        <TooltipContent
-          side={side}
-          sideOffset={6}
-          avoidCollisions={false}
-          className={className}
-        >
-          {tooltip}
-        </TooltipContent>
-      </Tooltip>
-    </TooltipProvider>
-  );
-};
+}: MessageActionProps) => (
+  <TooltipProvider>
+    <Tooltip {...props}>
+      <TooltipTrigger asChild>{children}</TooltipTrigger>
+      <TooltipContent
+        side={side}
+        sideOffset={6}
+        avoidCollisions={false}
+        className={className}
+      >
+        {tooltip}
+      </TooltipContent>
+    </Tooltip>
+  </TooltipProvider>
+);
 
 export {
   Message,

--- a/apps/desktop/src/mainview/ui/prompt-input.tsx
+++ b/apps/desktop/src/mainview/ui/prompt-input.tsx
@@ -38,9 +38,7 @@ const PromptInputContext = createContext<PromptInputContextType>({
   textareaRef: { current: null },
 });
 
-function usePromptInput() {
-  return useContext(PromptInputContext);
-}
+const usePromptInput = () => useContext(PromptInputContext);
 
 export type PromptInputProps = {
   isLoading?: boolean;
@@ -180,17 +178,15 @@ function PromptInputTextarea({
 
 export type PromptInputActionsProps = React.HTMLAttributes<HTMLDivElement>;
 
-function PromptInputActions({
+const PromptInputActions = ({
   children,
   className,
   ...props
-}: PromptInputActionsProps) {
-  return (
-    <div className={cn("flex items-center gap-2", className)} {...props}>
-      {children}
-    </div>
-  );
-}
+}: PromptInputActionsProps) => (
+  <div className={cn("flex items-center gap-2", className)} {...props}>
+    {children}
+  </div>
+);
 
 export type PromptInputActionProps = {
   className?: string;

--- a/apps/desktop/src/mainview/ui/sidebar.tsx
+++ b/apps/desktop/src/mainview/ui/sidebar.tsx
@@ -95,11 +95,11 @@ const SidebarProvider = React.forwardRef<
     );
 
     // Helper to toggle the sidebar.
-    const toggleSidebar = React.useCallback(() => {
-      return isMobile
-        ? setOpenMobile((open) => !open)
-        : setOpen((open) => !open);
-    }, [isMobile, setOpen, setOpenMobile]);
+    const toggleSidebar = React.useCallback(
+      () =>
+        isMobile ? setOpenMobile((open) => !open) : setOpen((open) => !open),
+      [isMobile, setOpen, setOpenMobile],
+    );
 
     // Adds a keyboard shortcut to toggle the sidebar.
     React.useEffect(() => {
@@ -334,115 +334,101 @@ SidebarRail.displayName = "SidebarRail";
 const SidebarInset = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"main">
->(({ className, ...props }, ref) => {
-  return (
-    <main
-      ref={ref}
-      className={cn(
-        "relative flex w-full flex-1 flex-col bg-background",
-        "md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
-        className,
-      )}
-      {...props}
-    />
-  );
-});
+>(({ className, ...props }, ref) => (
+  <main
+    ref={ref}
+    className={cn(
+      "relative flex w-full flex-1 flex-col bg-background",
+      "md:peer-data-[variant=inset]:m-2 md:peer-data-[state=collapsed]:peer-data-[variant=inset]:ml-2 md:peer-data-[variant=inset]:ml-0 md:peer-data-[variant=inset]:rounded-xl md:peer-data-[variant=inset]:shadow",
+      className,
+    )}
+    {...props}
+  />
+));
 SidebarInset.displayName = "SidebarInset";
 
 const SidebarInput = React.forwardRef<
   React.ElementRef<typeof Input>,
   React.ComponentProps<typeof Input>
->(({ className, ...props }, ref) => {
-  return (
-    <Input
-      ref={ref}
-      data-sidebar="input"
-      className={cn(
-        "h-8 w-full bg-background shadow-none focus-visible:ring-2 focus-visible:ring-sidebar-ring",
-        className,
-      )}
-      {...props}
-    />
-  );
-});
+>(({ className, ...props }, ref) => (
+  <Input
+    ref={ref}
+    data-sidebar="input"
+    className={cn(
+      "h-8 w-full bg-background shadow-none focus-visible:ring-2 focus-visible:ring-sidebar-ring",
+      className,
+    )}
+    {...props}
+  />
+));
 SidebarInput.displayName = "SidebarInput";
 
 const SidebarHeader = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div">
->(({ className, ...props }, ref) => {
-  return (
-    <div
-      ref={ref}
-      data-sidebar="header"
-      className={cn("flex flex-col gap-2 p-2", className)}
-      {...props}
-    />
-  );
-});
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    data-sidebar="header"
+    className={cn("flex flex-col gap-2 p-2", className)}
+    {...props}
+  />
+));
 SidebarHeader.displayName = "SidebarHeader";
 
 const SidebarFooter = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div">
->(({ className, ...props }, ref) => {
-  return (
-    <div
-      ref={ref}
-      data-sidebar="footer"
-      className={cn("flex flex-col gap-2 p-2", className)}
-      {...props}
-    />
-  );
-});
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    data-sidebar="footer"
+    className={cn("flex flex-col gap-2 p-2", className)}
+    {...props}
+  />
+));
 SidebarFooter.displayName = "SidebarFooter";
 
 const SidebarSeparator = React.forwardRef<
   React.ElementRef<typeof Separator>,
   React.ComponentProps<typeof Separator>
->(({ className, ...props }, ref) => {
-  return (
-    <Separator
-      ref={ref}
-      data-sidebar="separator"
-      className={cn("mx-2 w-auto bg-sidebar-border", className)}
-      {...props}
-    />
-  );
-});
+>(({ className, ...props }, ref) => (
+  <Separator
+    ref={ref}
+    data-sidebar="separator"
+    className={cn("mx-2 w-auto bg-sidebar-border", className)}
+    {...props}
+  />
+));
 SidebarSeparator.displayName = "SidebarSeparator";
 
 const SidebarContent = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div">
->(({ className, ...props }, ref) => {
-  return (
-    <div
-      ref={ref}
-      data-sidebar="content"
-      className={cn(
-        "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
-        className,
-      )}
-      {...props}
-    />
-  );
-});
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    data-sidebar="content"
+    className={cn(
+      "flex min-h-0 flex-1 flex-col gap-2 overflow-auto group-data-[collapsible=icon]:overflow-hidden",
+      className,
+    )}
+    {...props}
+  />
+));
 SidebarContent.displayName = "SidebarContent";
 
 const SidebarGroup = React.forwardRef<
   HTMLDivElement,
   React.ComponentProps<"div">
->(({ className, ...props }, ref) => {
-  return (
-    <div
-      ref={ref}
-      data-sidebar="group"
-      className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
-      {...props}
-    />
-  );
-});
+>(({ className, ...props }, ref) => (
+  <div
+    ref={ref}
+    data-sidebar="group"
+    className={cn("relative flex w-full min-w-0 flex-col p-2", className)}
+    {...props}
+  />
+));
 SidebarGroup.displayName = "SidebarGroup";
 
 const SidebarGroupLabel = React.forwardRef<
@@ -668,9 +654,10 @@ const SidebarMenuSkeleton = React.forwardRef<
   }
 >(({ className, showIcon = false, ...props }, ref) => {
   // Random width between 50 to 90%.
-  const width = React.useMemo(() => {
-    return `${Math.floor(Math.random() * 40) + 50}%`;
-  }, []);
+  const width = React.useMemo(
+    () => `${Math.floor(Math.random() * 40) + 50}%`,
+    [],
+  );
 
   return (
     <div

--- a/apps/desktop/src/mainview/ui/skeleton.tsx
+++ b/apps/desktop/src/mainview/ui/skeleton.tsx
@@ -1,15 +1,13 @@
 import { cn } from "~/lib/utils";
 
-function Skeleton({
+const Skeleton = ({
   className,
   ...props
-}: React.HTMLAttributes<HTMLDivElement>) {
-  return (
-    <div
-      className={cn("animate-pulse rounded-md bg-primary/10", className)}
-      {...props}
-    />
-  );
-}
+}: React.HTMLAttributes<HTMLDivElement>) => (
+  <div
+    className={cn("animate-pulse rounded-md bg-primary/10", className)}
+    {...props}
+  />
+);
 
 export { Skeleton };

--- a/apps/desktop/src/mainview/ui/textarea.tsx
+++ b/apps/desktop/src/mainview/ui/textarea.tsx
@@ -5,18 +5,16 @@ import { cn } from "~/lib/utils";
 const Textarea = React.forwardRef<
   HTMLTextAreaElement,
   React.ComponentProps<"textarea">
->(({ className, ...props }, ref) => {
-  return (
-    <textarea
-      className={cn(
-        "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
-        className,
-      )}
-      ref={ref}
-      {...props}
-    />
-  );
-});
+>(({ className, ...props }, ref) => (
+  <textarea
+    className={cn(
+      "flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+      className,
+    )}
+    ref={ref}
+    {...props}
+  />
+));
 Textarea.displayName = "Textarea";
 
 export { Textarea };

--- a/packages/db/src/repositories/agent-events.ts
+++ b/packages/db/src/repositories/agent-events.ts
@@ -21,55 +21,53 @@ export interface AgentEventListOptions {
 const clampLimit = (limit: number | undefined) =>
   Math.min(Math.max(limit ?? 1000, 1), 10_000);
 
-export function makeAgentEventsRepo(db: Db) {
-  return {
-    listForConversation(
-      conversationId: string,
-      options?: AgentEventListOptions,
-    ): schema.AgentEvent[] {
-      return db
-        .select()
-        .from(schema.agentEvents)
-        .where(eq(schema.agentEvents.conversationId, conversationId))
-        .orderBy(asc(schema.agentEvents.createdAt))
-        .limit(clampLimit(options?.limit))
-        .all();
-    },
+export const makeAgentEventsRepo = (db: Db) => ({
+  listForConversation(
+    conversationId: string,
+    options?: AgentEventListOptions,
+  ): schema.AgentEvent[] {
+    return db
+      .select()
+      .from(schema.agentEvents)
+      .where(eq(schema.agentEvents.conversationId, conversationId))
+      .orderBy(asc(schema.agentEvents.createdAt))
+      .limit(clampLimit(options?.limit))
+      .all();
+  },
 
-    listForRun(
-      runId: string,
-      options?: AgentEventListOptions,
-    ): schema.AgentEvent[] {
-      return db
-        .select()
-        .from(schema.agentEvents)
-        .where(eq(schema.agentEvents.runId, runId))
-        .orderBy(asc(schema.agentEvents.createdAt))
-        .limit(clampLimit(options?.limit))
-        .all();
-    },
+  listForRun(
+    runId: string,
+    options?: AgentEventListOptions,
+  ): schema.AgentEvent[] {
+    return db
+      .select()
+      .from(schema.agentEvents)
+      .where(eq(schema.agentEvents.runId, runId))
+      .orderBy(asc(schema.agentEvents.createdAt))
+      .limit(clampLimit(options?.limit))
+      .all();
+  },
 
-    append(input: NewAgentEventInput): schema.AgentEvent {
-      const row: schema.NewAgentEvent = {
-        id: input.id,
-        conversationId: input.conversationId,
-        runId: input.runId,
-        type: input.type,
-        eventJson: input.eventJson,
-        createdAt: input.createdAt,
-      };
-      db.transaction((tx) => {
-        tx.insert(schema.agentEvents).values(row).run();
-        if (input.conversationId) {
-          tx.update(schema.conversations)
-            .set({ updatedAt: input.createdAt })
-            .where(eq(schema.conversations.id, input.conversationId))
-            .run();
-        }
-      });
-      return row as schema.AgentEvent;
-    },
-  };
-}
+  append(input: NewAgentEventInput): schema.AgentEvent {
+    const row: schema.NewAgentEvent = {
+      id: input.id,
+      conversationId: input.conversationId,
+      runId: input.runId,
+      type: input.type,
+      eventJson: input.eventJson,
+      createdAt: input.createdAt,
+    };
+    db.transaction((tx) => {
+      tx.insert(schema.agentEvents).values(row).run();
+      if (input.conversationId) {
+        tx.update(schema.conversations)
+          .set({ updatedAt: input.createdAt })
+          .where(eq(schema.conversations.id, input.conversationId))
+          .run();
+      }
+    });
+    return row as schema.AgentEvent;
+  },
+});
 
 export type AgentEventsRepo = ReturnType<typeof makeAgentEventsRepo>;

--- a/packages/db/src/repositories/conversations.ts
+++ b/packages/db/src/repositories/conversations.ts
@@ -23,84 +23,82 @@ export interface ConversationListOptions {
 const clampLimit = (limit: number | undefined) =>
   Math.min(Math.max(limit ?? 200, 1), 1000);
 
-export function makeConversationsRepo(db: Db) {
-  return {
-    list(
-      scope: ConversationListScope = "active",
-      options?: ConversationListOptions,
-    ): schema.Conversation[] {
-      const order = desc(schema.conversations.updatedAt);
-      if (scope === "all") {
-        return db
-          .select()
-          .from(schema.conversations)
-          .orderBy(order)
-          .limit(clampLimit(options?.limit))
-          .all();
-      }
-      const archivedInt = scope === "archived" ? 1 : 0;
+export const makeConversationsRepo = (db: Db) => ({
+  list(
+    scope: ConversationListScope = "active",
+    options?: ConversationListOptions,
+  ): schema.Conversation[] {
+    const order = desc(schema.conversations.updatedAt);
+    if (scope === "all") {
       return db
         .select()
         .from(schema.conversations)
-        .where(eq(schema.conversations.archived, archivedInt))
         .orderBy(order)
         .limit(clampLimit(options?.limit))
         .all();
-    },
+    }
+    const archivedInt = scope === "archived" ? 1 : 0;
+    return db
+      .select()
+      .from(schema.conversations)
+      .where(eq(schema.conversations.archived, archivedInt))
+      .orderBy(order)
+      .limit(clampLimit(options?.limit))
+      .all();
+  },
 
-    get(id: string): schema.Conversation | null {
-      return (
-        db
-          .select()
-          .from(schema.conversations)
-          .where(eq(schema.conversations.id, id))
-          .get() ?? null
-      );
-    },
-
-    create(input: NewConversationInput): schema.Conversation {
-      const now = Date.now();
-      const id = input.id ?? newId();
-      const row: schema.NewConversation = {
-        id,
-        title: input.title,
-        model: input.model ?? null,
-        archived: 0,
-        createdAt: now,
-        updatedAt: now,
-      };
-      db.insert(schema.conversations).values(row).run();
-      return { ...row, model: row.model ?? null } as schema.Conversation;
-    },
-
-    rename(id: string, title: string): void {
-      db.update(schema.conversations)
-        .set({ title, updatedAt: Date.now() })
+  get(id: string): schema.Conversation | null {
+    return (
+      db
+        .select()
+        .from(schema.conversations)
         .where(eq(schema.conversations.id, id))
-        .run();
-    },
+        .get() ?? null
+    );
+  },
 
-    touch(id: string): void {
-      db.update(schema.conversations)
-        .set({ updatedAt: Date.now() })
-        .where(eq(schema.conversations.id, id))
-        .run();
-    },
+  create(input: NewConversationInput): schema.Conversation {
+    const now = Date.now();
+    const id = input.id ?? newId();
+    const row: schema.NewConversation = {
+      id,
+      title: input.title,
+      model: input.model ?? null,
+      archived: 0,
+      createdAt: now,
+      updatedAt: now,
+    };
+    db.insert(schema.conversations).values(row).run();
+    return { ...row, model: row.model ?? null } as schema.Conversation;
+  },
 
-    setArchived(id: string, archived: boolean): void {
-      db.update(schema.conversations)
-        .set({ archived: archived ? 1 : 0, updatedAt: Date.now() })
-        .where(eq(schema.conversations.id, id))
-        .run();
-    },
+  rename(id: string, title: string): void {
+    db.update(schema.conversations)
+      .set({ title, updatedAt: Date.now() })
+      .where(eq(schema.conversations.id, id))
+      .run();
+  },
 
-    delete(id: string): void {
-      // Messages cascade via FK.
-      db.delete(schema.conversations)
-        .where(eq(schema.conversations.id, id))
-        .run();
-    },
-  };
-}
+  touch(id: string): void {
+    db.update(schema.conversations)
+      .set({ updatedAt: Date.now() })
+      .where(eq(schema.conversations.id, id))
+      .run();
+  },
+
+  setArchived(id: string, archived: boolean): void {
+    db.update(schema.conversations)
+      .set({ archived: archived ? 1 : 0, updatedAt: Date.now() })
+      .where(eq(schema.conversations.id, id))
+      .run();
+  },
+
+  delete(id: string): void {
+    // Messages cascade via FK.
+    db.delete(schema.conversations)
+      .where(eq(schema.conversations.id, id))
+      .run();
+  },
+});
 
 export type ConversationsRepo = ReturnType<typeof makeConversationsRepo>;

--- a/packages/db/src/repositories/messages.ts
+++ b/packages/db/src/repositories/messages.ts
@@ -23,47 +23,42 @@ const newId = (): string =>
 const clampLimit = (limit: number | undefined) =>
   Math.min(Math.max(limit ?? 500, 1), 5000);
 
-export function makeMessagesRepo(db: Db) {
-  return {
-    list(
-      conversationId: string,
-      options?: MessageListOptions,
-    ): schema.Message[] {
-      return db
-        .select()
-        .from(schema.messages)
-        .where(eq(schema.messages.conversationId, conversationId))
-        .orderBy(asc(schema.messages.createdAt))
-        .limit(clampLimit(options?.limit))
-        .all();
-    },
+export const makeMessagesRepo = (db: Db) => ({
+  list(conversationId: string, options?: MessageListOptions): schema.Message[] {
+    return db
+      .select()
+      .from(schema.messages)
+      .where(eq(schema.messages.conversationId, conversationId))
+      .orderBy(asc(schema.messages.createdAt))
+      .limit(clampLimit(options?.limit))
+      .all();
+  },
 
-    append(input: NewMessageInput): schema.Message {
-      const now = Date.now();
-      const row: schema.NewMessage = {
-        id: input.id ?? newId(),
-        conversationId: input.conversationId,
-        role: input.role,
-        content: input.content,
-        partsJson: input.partsJson ?? null,
-        createdAt: now,
-      };
-      // Append message + bump the conversation's updatedAt in one transaction
-      // so the sidebar's "most recent first" ordering stays accurate.
-      db.transaction((tx) => {
-        tx.insert(schema.messages).values(row).run();
-        tx.update(schema.conversations)
-          .set({ updatedAt: now })
-          .where(eq(schema.conversations.id, input.conversationId))
-          .run();
-      });
-      return row as schema.Message;
-    },
+  append(input: NewMessageInput): schema.Message {
+    const now = Date.now();
+    const row: schema.NewMessage = {
+      id: input.id ?? newId(),
+      conversationId: input.conversationId,
+      role: input.role,
+      content: input.content,
+      partsJson: input.partsJson ?? null,
+      createdAt: now,
+    };
+    // Append message + bump the conversation's updatedAt in one transaction
+    // so the sidebar's "most recent first" ordering stays accurate.
+    db.transaction((tx) => {
+      tx.insert(schema.messages).values(row).run();
+      tx.update(schema.conversations)
+        .set({ updatedAt: now })
+        .where(eq(schema.conversations.id, input.conversationId))
+        .run();
+    });
+    return row as schema.Message;
+  },
 
-    delete(id: string): void {
-      db.delete(schema.messages).where(eq(schema.messages.id, id)).run();
-    },
-  };
-}
+  delete(id: string): void {
+    db.delete(schema.messages).where(eq(schema.messages.id, id)).run();
+  },
+});
 
 export type MessagesRepo = ReturnType<typeof makeMessagesRepo>;

--- a/packages/db/src/repositories/preferences.ts
+++ b/packages/db/src/repositories/preferences.ts
@@ -11,79 +11,75 @@ type Db = BunSQLiteDatabase<typeof schema>;
  * because bun:sqlite is sync — wrap at the consumer edge if the surrounding
  * code expects async.
  */
-export function makePreferencesRepo(db: Db) {
-  return {
-    get<T>(key: string): T | null {
-      const row = db
-        .select()
-        .from(schema.preferences)
-        .where(eq(schema.preferences.key, key))
-        .get();
-      if (!row) return null;
+export const makePreferencesRepo = (db: Db) => ({
+  get<T>(key: string): T | null {
+    const row = db
+      .select()
+      .from(schema.preferences)
+      .where(eq(schema.preferences.key, key))
+      .get();
+    if (!row) return null;
+    try {
+      return JSON.parse(row.value) as T;
+    } catch {
+      return null;
+    }
+  },
+
+  getAll(): Record<string, unknown> {
+    const rows = db.select().from(schema.preferences).all();
+    const out: Record<string, unknown> = {};
+    for (const r of rows) {
       try {
-        return JSON.parse(row.value) as T;
+        out[r.key] = JSON.parse(r.value);
       } catch {
-        return null;
+        // ignore corrupt row
       }
-    },
+    }
+    return out;
+  },
 
-    getAll(): Record<string, unknown> {
-      const rows = db.select().from(schema.preferences).all();
-      const out: Record<string, unknown> = {};
-      for (const r of rows) {
-        try {
-          out[r.key] = JSON.parse(r.value);
-        } catch {
-          // ignore corrupt row
-        }
+  set(key: string, value: unknown): void {
+    const now = Date.now();
+    db.insert(schema.preferences)
+      .values({ key, value: JSON.stringify(value), updatedAt: now })
+      .onConflictDoUpdate({
+        target: schema.preferences.key,
+        set: { value: JSON.stringify(value), updatedAt: now },
+      })
+      .run();
+  },
+
+  setMany(entries: Record<string, unknown>): void {
+    // Single transaction so partial writes don't leave drift.
+    const now = Date.now();
+    const items = Object.entries(entries);
+    if (items.length === 0) return;
+    db.transaction((tx) => {
+      for (const [key, value] of items) {
+        tx.insert(schema.preferences)
+          .values({ key, value: JSON.stringify(value), updatedAt: now })
+          .onConflictDoUpdate({
+            target: schema.preferences.key,
+            set: { value: JSON.stringify(value), updatedAt: now },
+          })
+          .run();
       }
-      return out;
-    },
+    });
+  },
 
-    set(key: string, value: unknown): void {
-      const now = Date.now();
-      db.insert(schema.preferences)
-        .values({ key, value: JSON.stringify(value), updatedAt: now })
-        .onConflictDoUpdate({
-          target: schema.preferences.key,
-          set: { value: JSON.stringify(value), updatedAt: now },
-        })
-        .run();
-    },
+  delete(key: string): void {
+    db.delete(schema.preferences).where(eq(schema.preferences.key, key)).run();
+  },
 
-    setMany(entries: Record<string, unknown>): void {
-      // Single transaction so partial writes don't leave drift.
-      const now = Date.now();
-      const items = Object.entries(entries);
-      if (items.length === 0) return;
-      db.transaction((tx) => {
-        for (const [key, value] of items) {
-          tx.insert(schema.preferences)
-            .values({ key, value: JSON.stringify(value), updatedAt: now })
-            .onConflictDoUpdate({
-              target: schema.preferences.key,
-              set: { value: JSON.stringify(value), updatedAt: now },
-            })
-            .run();
-        }
-      });
-    },
-
-    delete(key: string): void {
-      db.delete(schema.preferences)
-        .where(eq(schema.preferences.key, key))
-        .run();
-    },
-
-    /**
-     * Total count of user-visible keys (excluding internal book-keeping like
-     * `_schema_version`). Used to detect a fresh DB for first-run JSON import.
-     */
-    count(): number {
-      const rows = db.select().from(schema.preferences).all();
-      return rows.filter((r) => !r.key.startsWith("_")).length;
-    },
-  };
-}
+  /**
+   * Total count of user-visible keys (excluding internal book-keeping like
+   * `_schema_version`). Used to detect a fresh DB for first-run JSON import.
+   */
+  count(): number {
+    const rows = db.select().from(schema.preferences).all();
+    return rows.filter((r) => !r.key.startsWith("_")).length;
+  },
+});
 
 export type PreferencesRepo = ReturnType<typeof makePreferencesRepo>;

--- a/packages/db/src/schema.test.ts
+++ b/packages/db/src/schema.test.ts
@@ -2,37 +2,33 @@ import { describe, expect, test } from "bun:test";
 
 import { createDb } from "./client.js";
 
-function tableNames(db: ReturnType<typeof createDb>) {
-  return db.raw
+const tableNames = (db: ReturnType<typeof createDb>) =>
+  db.raw
     .prepare(
       "SELECT name FROM sqlite_master WHERE type = 'table' ORDER BY name",
     )
     .all() as Array<{ name: string }>;
-}
 
-function indexNames(db: ReturnType<typeof createDb>) {
-  return db.raw
+const indexNames = (db: ReturnType<typeof createDb>) =>
+  db.raw
     .prepare(
       "SELECT name FROM sqlite_master WHERE type = 'index' ORDER BY name",
     )
     .all() as Array<{ name: string }>;
-}
 
-function strictTables(db: ReturnType<typeof createDb>) {
-  return db.raw.prepare("PRAGMA table_list").all() as Array<{
+const strictTables = (db: ReturnType<typeof createDb>) =>
+  db.raw.prepare("PRAGMA table_list").all() as Array<{
     name: string;
     strict: number;
   }>;
-}
 
-function foreignKeys(db: ReturnType<typeof createDb>, table: string) {
-  return db.raw.prepare(`PRAGMA foreign_key_list(${table})`).all() as Array<{
+const foreignKeys = (db: ReturnType<typeof createDb>, table: string) =>
+  db.raw.prepare(`PRAGMA foreign_key_list(${table})`).all() as Array<{
     table: string;
     from: string;
     to: string;
     on_delete: string;
   }>;
-}
 
 describe("db schema", () => {
   test("applies drizzle migrations for core tables and indexes", () => {

--- a/packages/lib/src/image-path.ts
+++ b/packages/lib/src/image-path.ts
@@ -33,15 +33,15 @@ export function normalizeImagePath(value: string): string {
   return s.trim();
 }
 
-export function looksLikeImagePath(value: string): boolean {
-  return IMAGE_EXT_RE.test(normalizeImagePath(value));
-}
+export const looksLikeImagePath = (value: string): boolean =>
+  IMAGE_EXT_RE.test(normalizeImagePath(value));
 
 /** Returns the image MIME type for a path by file extension, or `null`. */
 export function imageMimeForPath(path: string): string | null {
   const dot = path.lastIndexOf(".");
-  if (dot === -1) return null;
-  return MIME_BY_EXT[path.slice(dot).toLowerCase()] ?? null;
+  return dot === -1
+    ? null
+    : (MIME_BY_EXT[path.slice(dot).toLowerCase()] ?? null);
 }
 
 /**
@@ -51,9 +51,7 @@ export function imageMimeForPath(path: string): string | null {
  */
 export const IMAGE_TOKEN_RE = /\[Image #(\d+)\]/g;
 
-export function formatImageToken(n: number): string {
-  return `[Image #${n}]`;
-}
+export const formatImageToken = (n: number): string => `[Image #${n}]`;
 
 /**
  * Parses inline image tokens out of `text` and returns the cleaned prompt
@@ -102,10 +100,11 @@ export function findInsertedImagePath(
     s++;
   }
   const inserted = next.slice(p, next.length - s);
-  if (!inserted || !looksLikeImagePath(inserted)) return null;
-  return {
-    path: normalizeImagePath(inserted),
-    startIdx: p,
-    endIdx: next.length - s,
-  };
+  return !inserted || !looksLikeImagePath(inserted)
+    ? null
+    : {
+        path: normalizeImagePath(inserted),
+        startIdx: p,
+        endIdx: next.length - s,
+      };
 }

--- a/packages/lib/src/narration-text.ts
+++ b/packages/lib/src/narration-text.ts
@@ -9,8 +9,8 @@ const joinParts = (parts: string[]): string =>
     .replace(/\n{3,}/g, "\n\n")
     .trim();
 
-function inlineTokensToSpeech(tokens: readonly Token[] = []): string {
-  return joinParts(
+const inlineTokensToSpeech = (tokens: readonly Token[] = []): string =>
+  joinParts(
     tokens.map((token) => {
       switch (token.type) {
         case "text":
@@ -40,7 +40,6 @@ function inlineTokensToSpeech(tokens: readonly Token[] = []): string {
       }
     }),
   );
-}
 
 function blockTokenToSpeech(token: Token): string {
   switch (token.type) {

--- a/packages/lib/src/result.ts
+++ b/packages/lib/src/result.ts
@@ -1,3 +1,2 @@
-export function toError(e: unknown): Error {
-  return e instanceof Error ? e : new Error(String(e));
-}
+export const toError = (e: unknown): Error =>
+  e instanceof Error ? e : new Error(String(e));

--- a/packages/sdk/src/audio-devices.ts
+++ b/packages/sdk/src/audio-devices.ts
@@ -9,11 +9,11 @@ export class AudioDeviceError extends Data.TaggedError("AudioDeviceError")<{
   readonly cause?: unknown;
 }> {}
 
-export function listInputDevices(): Effect.Effect<
+export const listInputDevices = (): Effect.Effect<
   AudioDevice[],
   AudioDeviceError
-> {
-  return Effect.tryPromise({
+> =>
+  Effect.tryPromise({
     try: () =>
       new Promise<AudioDevice[]>((resolve, reject) => {
         const proc = spawn(
@@ -50,7 +50,6 @@ export function listInputDevices(): Effect.Effect<
         cause,
       }),
   });
-}
 
 function parseAvFoundationDevices(output: string): AudioDevice[] {
   const lines = output.split("\n");
@@ -83,8 +82,7 @@ const OUTPUT_SYSTEM_DEFAULT: AudioDevice[] = [
   { index: 0, name: "System default" },
 ];
 
-export function listOutputDevices(): Effect.Effect<AudioDevice[], never> {
-  return Effect.succeed(OUTPUT_SYSTEM_DEFAULT);
-}
+export const listOutputDevices = (): Effect.Effect<AudioDevice[], never> =>
+  Effect.succeed(OUTPUT_SYSTEM_DEFAULT);
 
 export type { AudioDevice } from "./types.js";

--- a/packages/sdk/src/health.ts
+++ b/packages/sdk/src/health.ts
@@ -61,10 +61,10 @@ export class HealthProbeError extends Data.TaggedError("HealthProbeError")<{
  * channel as {@link HealthProbeError}. Apps typically render them as a
  * "(unreachable)" footer rather than a hard error.
  */
-export function probeHealth(
+export const probeHealth = (
   baseUrl: string,
-): Effect.Effect<HealthSnapshot, HealthProbeError> {
-  return Effect.tryPromise({
+): Effect.Effect<HealthSnapshot, HealthProbeError> =>
+  Effect.tryPromise({
     try: async () => {
       const res = await fetch(`${trimTrailingSlash(baseUrl)}/health`);
       if (!res.ok) {
@@ -91,4 +91,3 @@ export function probeHealth(
         cause,
       }),
   });
-}

--- a/packages/sdk/src/mcp.ts
+++ b/packages/sdk/src/mcp.ts
@@ -103,16 +103,13 @@ export class McpManager {
         try: () => McpConfigSchema.safeParse(JSON.parse(content)),
         catch: toMcpError,
       });
-      if (!parsed.success) {
-        return yield* Effect.fail(
-          new McpError({
-            message: `Invalid MCP config: ${parsed.error.message}`,
-          }),
-        );
-      }
-      return yield* Effect.promise(() =>
-        this.connectAll(parsed.data.mcpServers),
-      );
+      return !parsed.success
+        ? yield* Effect.fail(
+            new McpError({
+              message: `Invalid MCP config: ${parsed.error.message}`,
+            }),
+          )
+        : yield* Effect.promise(() => this.connectAll(parsed.data.mcpServers));
     });
   }
 

--- a/packages/sdk/src/paths.ts
+++ b/packages/sdk/src/paths.ts
@@ -34,7 +34,5 @@ export function resolveMcpConfigPath(): string {
   if (fs.existsSync(yappr)) return yappr;
 
   const cursor = MCP_CONFIG_PRESETS.cursor();
-  if (fs.existsSync(cursor)) return cursor;
-
-  return yappr;
+  return fs.existsSync(cursor) ? cursor : yappr;
 }

--- a/packages/sdk/src/speech-presets.ts
+++ b/packages/sdk/src/speech-presets.ts
@@ -38,16 +38,14 @@ export interface YapprPresetOverrides {
   speed?: number;
 }
 
-export function yapprSpeechPreset(
+export const yapprSpeechPreset = (
   overrides: YapprPresetOverrides = {},
-): YapprSpeechEndpointInput {
-  return {
-    kind: "yappr",
-    baseUrl: overrides.baseUrl ?? DEFAULT_SERVER_URL,
-    voice: overrides.voice ?? DEFAULT_VOICE,
-    speed: overrides.speed ?? DEFAULT_SPEED,
-  };
-}
+): YapprSpeechEndpointInput => ({
+  kind: "yappr",
+  baseUrl: overrides.baseUrl ?? DEFAULT_SERVER_URL,
+  voice: overrides.voice ?? DEFAULT_VOICE,
+  speed: overrides.speed ?? DEFAULT_SPEED,
+});
 
 export interface CustomOpenAiPresetOverrides {
   baseUrl?: string;
@@ -62,18 +60,16 @@ export interface CustomOpenAiPresetOverrides {
  * requires a non-empty string in both fields so we ship sensible literals
  * users will recognise and want to replace.
  */
-export function customOpenAiSpeechPreset(
+export const customOpenAiSpeechPreset = (
   overrides: CustomOpenAiPresetOverrides = {},
-): OpenAiCompatibleSpeechEndpointInput {
-  return {
-    kind: "openai-compatible",
-    baseUrl: overrides.baseUrl ?? "https://api.example.com/v1",
-    ...(overrides.apiKey ? { apiKey: overrides.apiKey } : {}),
-    model: overrides.model ?? "tts-1",
-    voice: overrides.voice ?? "alloy",
-    format: "wav",
-  };
-}
+): OpenAiCompatibleSpeechEndpointInput => ({
+  kind: "openai-compatible",
+  baseUrl: overrides.baseUrl ?? "https://api.example.com/v1",
+  ...(overrides.apiKey ? { apiKey: overrides.apiKey } : {}),
+  model: overrides.model ?? "tts-1",
+  voice: overrides.voice ?? "alloy",
+  format: "wav",
+});
 
 export type SpeechPresetOverrides = {
   baseUrl?: string;
@@ -88,11 +84,11 @@ export type SpeechPresetOverrides = {
  * from a UI control; the returned shape plugs straight into
  * `VoiceConfigInput.speech`.
  */
-export function buildSpeechPreset(
+export const buildSpeechPreset = (
   kind: SpeechPresetKind,
   overrides: SpeechPresetOverrides = {},
-): YapprSpeechEndpointInput | OpenAiCompatibleSpeechEndpointInput {
-  return match(kind)
+): YapprSpeechEndpointInput | OpenAiCompatibleSpeechEndpointInput =>
+  match(kind)
     .with("yappr", () => yapprSpeechPreset(overrides))
     .with("voxtral", () =>
       voxtralSpeechPreset({
@@ -105,21 +101,19 @@ export function buildSpeechPreset(
     )
     .with("custom", () => customOpenAiSpeechPreset(overrides))
     .exhaustive();
-}
 
 /**
  * Inverse of {@link buildSpeechPreset}: detect the preset a config came from
  * so the UI can highlight the active row. Anything openai-compatible that
  * isn't Voxtral is treated as custom.
  */
-export function detectSpeechPreset(
+export const detectSpeechPreset = (
   speech: YapprSpeechEndpointInput | OpenAiCompatibleSpeechEndpointInput,
-): SpeechPresetKind {
-  return match(speech)
+): SpeechPresetKind =>
+  match(speech)
     .with({ kind: "yappr" }, () => "yappr" as const)
     .with(
       { kind: "openai-compatible", model: VOXTRAL_MODEL_ID },
       () => "voxtral" as const,
     )
     .otherwise(() => "custom" as const);
-}

--- a/packages/sdk/src/voice.ts
+++ b/packages/sdk/src/voice.ts
@@ -234,28 +234,28 @@ export function createSpeechClient(
   endpoint: SpeechEndpointInput,
 ): YapprSpeechClient | OpenAiCompatibleSpeechClient {
   const parsed = SpeechEndpointSchema.parse(endpoint);
-  if (parsed.kind === "yappr") return new YapprSpeechClient(parsed);
-  return new OpenAiCompatibleSpeechClient(parsed);
+  return parsed.kind === "yappr"
+    ? new YapprSpeechClient(parsed)
+    : new OpenAiCompatibleSpeechClient(parsed);
 }
 
 export function createTranscriptionClient(
   endpoint: TranscriptionEndpointInput,
 ): YapprTranscriptionClient | OpenAiCompatibleTranscriptionClient {
   const parsed = TranscriptionEndpointSchema.parse(endpoint);
-  if (parsed.kind === "yappr") return new YapprTranscriptionClient(parsed);
-  return new OpenAiCompatibleTranscriptionClient(parsed);
+  return parsed.kind === "yappr"
+    ? new YapprTranscriptionClient(parsed)
+    : new OpenAiCompatibleTranscriptionClient(parsed);
 }
 
-export function createVoiceClient(
+export const createVoiceClient = (
   config: VoiceConfigInput = DEFAULT_VOICE_CONFIG,
-): VoiceClient {
-  return new EndpointVoiceClient(config);
-}
+): VoiceClient => new EndpointVoiceClient(config);
 
-export function localVoiceConfig(
+export const localVoiceConfig = (
   baseUrl: string = DEFAULT_SERVER_URL,
-): VoiceConfig {
-  return VoiceConfigSchema.parse({
+): VoiceConfig =>
+  VoiceConfigSchema.parse({
     speech: {
       ...DEFAULT_VOICE_CONFIG.speech,
       baseUrl,
@@ -265,7 +265,6 @@ export function localVoiceConfig(
       baseUrl,
     },
   });
-}
 
 export function withSpeechEndpoint(
   config: VoiceConfigInput,

--- a/packages/sdk/src/voxtral-voices.ts
+++ b/packages/sdk/src/voxtral-voices.ts
@@ -65,9 +65,8 @@ export type VoxtralVoiceId = (typeof VOXTRAL_VOICES)[number];
 
 const VOXTRAL_VOICE_SET = new Set<string>(VOXTRAL_VOICES);
 
-export function isVoxtralVoiceId(value: string): value is VoxtralVoiceId {
-  return VOXTRAL_VOICE_SET.has(value);
-}
+export const isVoxtralVoiceId = (value: string): value is VoxtralVoiceId =>
+  VOXTRAL_VOICE_SET.has(value);
 
 export const VOXTRAL_MODEL_ID = "mistralai/Voxtral-4B-TTS-2603";
 
@@ -89,17 +88,15 @@ export const VOXTRAL_DEFAULT_VOICE: VoxtralVoiceId = "casual_male";
  * instance serving Voxtral. Apps use this as a one-click "Voxtral preset" so
  * users don't have to type the model id / voice field / format by hand.
  */
-export function voxtralSpeechPreset(overrides?: {
+export const voxtralSpeechPreset = (overrides?: {
   baseUrl?: string;
   apiKey?: string;
   voice?: VoxtralVoiceId;
-}) {
-  return {
-    kind: "openai-compatible" as const,
-    baseUrl: overrides?.baseUrl ?? VOXTRAL_DEFAULT_BASE_URL,
-    ...(overrides?.apiKey ? { apiKey: overrides.apiKey } : {}),
-    model: VOXTRAL_MODEL_ID,
-    voice: overrides?.voice ?? VOXTRAL_DEFAULT_VOICE,
-    format: VOXTRAL_DEFAULT_RESPONSE_FORMAT,
-  };
-}
+}) => ({
+  kind: "openai-compatible" as const,
+  baseUrl: overrides?.baseUrl ?? VOXTRAL_DEFAULT_BASE_URL,
+  ...(overrides?.apiKey ? { apiKey: overrides.apiKey } : {}),
+  model: VOXTRAL_MODEL_ID,
+  voice: overrides?.voice ?? VOXTRAL_DEFAULT_VOICE,
+  format: VOXTRAL_DEFAULT_RESPONSE_FORMAT,
+});

--- a/scripts/smoke-tts-stt.ts
+++ b/scripts/smoke-tts-stt.ts
@@ -100,15 +100,14 @@ async function transcribe(baseUrl: string, wav: Uint8Array): Promise<string> {
   return body.text ?? "";
 }
 
-function tokenize(input: string): Set<string> {
-  return new Set(
+const tokenize = (input: string): Set<string> =>
+  new Set(
     input
       .toLowerCase()
       .replace(/[^\p{L}\p{N}\s]/gu, " ")
       .split(/\s+/)
       .filter(Boolean),
   );
-}
 
 function jaccardSimilarity(a: string, b: string): number {
   const left = tokenize(a);
@@ -119,9 +118,7 @@ function jaccardSimilarity(a: string, b: string): number {
   return intersection.size / union.size;
 }
 
-function format(n: number): string {
-  return n.toFixed(3);
-}
+const format = (n: number): string => n.toFixed(3);
 
 async function main(): Promise<void> {
   const args = parseCliArgs();
@@ -169,7 +166,7 @@ async function main(): Promise<void> {
   const wavPath = join(tmpdir(), `yappr-smoke-${Date.now()}.wav`);
   await writeFile(wavPath, wav);
 
-  console.log(`▶ STT: transcribing…`);
+  console.log("▶ STT: transcribing…");
   const sttStart = Date.now();
   let transcript: string;
   try {
@@ -204,7 +201,7 @@ async function main(): Promise<void> {
     );
     process.exit(1);
   }
-  console.log(`\n✓ PASS`);
+  console.log("\n✓ PASS");
 }
 
 void main();


### PR DESCRIPTION
Ran `@onrails/codemod --tersify` across the repo — verbose single-return `function` declarations rewritten to concise arrows, redundant blocks collapsed. **81 files, behaviour-preserving.**

One manual fixup: tersify collapsed an `if`-guard into a ternary in `footer.tsx` but left the relocated single-child Fragment, tripping biome `noUselessFragments`. Unwrapped by hand; filed upstream on alanrsoares/onrails.

Verified: biome clean · typecheck 5/5 · 87 tests.

Note: runs off `main`, so the open #24 (PR #28) files aren't covered — the codemod is idempotent, re-run after #28 merges.